### PR TITLE
refactor(ad_plaza): split Earn and Advertise pages and rebuild Earn layout

### DIFF
--- a/dist/css/ad_advertise.css
+++ b/dist/css/ad_advertise.css
@@ -1,0 +1,707 @@
+/* Ad Plaza Advertise CSS Styles */
+
+/* ==================== Global Styles ==================== */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #f5f5f5;
+    color: #333;
+    line-height: 1.6;
+}
+
+/* ==================== Top Header ==================== */
+.plaza-header {
+    background: white;
+    border-bottom: 1px solid #e5e7eb;
+    padding: 16px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.plaza-header-left {
+    flex: 0 0 auto;
+}
+
+.plaza-logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 20px;
+    font-weight: 700;
+    color: #667eea;
+}
+
+.logo-icon {
+    font-size: 28px;
+}
+
+.plaza-header-right {
+    flex: 0 0 auto;
+}
+
+.account-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.account-balance {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: #f3f4f6;
+    border-radius: 8px;
+}
+
+.balance-label {
+    font-size: 14px;
+    color: #6b7280;
+}
+
+.balance-value {
+    font-size: 16px;
+    font-weight: 600;
+    color: #10b981;
+}
+
+.btn-recharge, .btn-history {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-recharge {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.btn-recharge:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.btn-history {
+    background: white;
+    color: #374151;
+    border: 1px solid #e5e7eb;
+}
+
+.btn-history:hover {
+    background: #f9fafb;
+}
+
+/* ==================== Plaza Views ==================== */
+.plaza-view {
+    padding: 32px;
+    max-width: 1400px;
+    margin: 0 auto;
+}
+
+/* ==================== Dashboard Overview (Advertise Mode) ==================== */
+.dashboard-overview {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+    margin-bottom: 32px;
+}
+
+.dashboard-card {
+    background: white;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    transition: transform 0.2s;
+}
+
+.dashboard-card:hover {
+    transform: translateY(-2px);
+}
+
+.dashboard-card .card-icon {
+    font-size: 36px;
+    flex-shrink: 0;
+}
+
+.dashboard-card .card-content {
+    flex: 1;
+}
+
+.dashboard-card .card-label {
+    font-size: 13px;
+    color: #6b7280;
+    margin-bottom: 4px;
+}
+
+.dashboard-card .card-value {
+    font-size: 24px;
+    font-weight: 700;
+    color: #374151;
+}
+
+.btn-card-action {
+    padding: 8px 16px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.btn-card-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+/* ==================== Publish Ad Section ==================== */
+.publish-ad-section {
+    margin-bottom: 32px;
+    text-align: center;
+}
+
+.btn-publish-ad {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 40px;
+    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+.btn-publish-ad:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(16, 185, 129, 0.4);
+}
+
+.publish-icon {
+    font-size: 20px;
+}
+
+/* ==================== Sections ==================== */
+.my-ads-section, .spending-section {
+    margin-bottom: 32px;
+}
+
+.section-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 16px;
+}
+
+/* ==================== Tables ==================== */
+.ads-table-container, .spending-table-container {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+}
+
+.ads-table, .spending-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.ads-table thead, .spending-table thead {
+    background: #f9fafb;
+}
+
+.ads-table th, .spending-table th {
+    padding: 12px 16px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: #374151;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.ads-table td, .spending-table td {
+    padding: 16px;
+    font-size: 14px;
+    color: #6b7280;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.ads-table tbody tr:hover, .spending-table tbody tr:hover {
+    background: #f9fafb;
+}
+
+.empty-row td {
+    text-align: center;
+    padding: 40px;
+}
+
+.empty-state-small {
+    color: #9ca3af;
+    font-size: 14px;
+}
+
+/* ==================== Modal Styles ==================== */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+
+.modal.active {
+    display: flex;
+}
+
+.modal-dialog {
+    background: white;
+    border-radius: 16px;
+    width: 100%;
+    max-width: 600px;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modal-large {
+    max-width: 900px;
+}
+
+.modal-wizard {
+    max-width: 700px;
+}
+
+.modal-header {
+    padding: 24px;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.modal-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: #374151;
+}
+
+.btn-close {
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    font-size: 24px;
+    color: #6b7280;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: all 0.2s;
+}
+
+.btn-close:hover {
+    background: #f3f4f6;
+    color: #374151;
+}
+
+.modal-body {
+    padding: 24px;
+}
+
+.modal-footer {
+    padding: 24px;
+    border-top: 1px solid #e5e7eb;
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+/* ==================== Wizard Steps ==================== */
+.wizard-steps {
+    display: flex;
+    justify-content: space-between;
+    padding: 24px 24px 0;
+    position: relative;
+}
+
+.wizard-steps::before {
+    content: '';
+    position: absolute;
+    top: 44px;
+    left: 24px;
+    right: 24px;
+    height: 2px;
+    background: #e5e7eb;
+    z-index: 0;
+}
+
+.wizard-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    position: relative;
+    z-index: 1;
+}
+
+.step-number {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #e5e7eb;
+    color: #9ca3af;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 16px;
+    transition: all 0.3s;
+}
+
+.wizard-step.active .step-number {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.wizard-step.completed .step-number {
+    background: #10b981;
+    color: white;
+}
+
+.step-label {
+    font-size: 12px;
+    color: #9ca3af;
+    font-weight: 500;
+}
+
+.wizard-step.active .step-label {
+    color: #667eea;
+}
+
+/* ==================== Wizard Content ==================== */
+.wizard-content {
+    display: none;
+}
+
+.wizard-content.active {
+    display: block;
+}
+
+.wizard-content h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 20px;
+}
+
+/* ==================== Form Styles ==================== */
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    margin-bottom: 8px;
+}
+
+.form-input, .form-select, .form-textarea {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    font-size: 14px;
+    transition: all 0.2s;
+}
+
+.form-input:focus, .form-select:focus, .form-textarea:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.form-hint {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+/* ==================== Budget Summary ==================== */
+.budget-summary {
+    background: #f9fafb;
+    padding: 20px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+}
+
+.summary-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    font-size: 14px;
+}
+
+.summary-row.total {
+    border-top: 2px solid #e5e7eb;
+    margin-top: 8px;
+    padding-top: 12px;
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.summary-label {
+    color: #6b7280;
+}
+
+.summary-value {
+    color: #374151;
+    font-weight: 500;
+}
+
+/* ==================== Balance Check ==================== */
+.balance-check {
+    padding: 16px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+}
+
+.balance-check-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    font-size: 14px;
+}
+
+.balance-status {
+    padding: 12px;
+    border-radius: 6px;
+    font-size: 14px;
+    text-align: center;
+}
+
+.balance-status.sufficient {
+    background: #d1fae5;
+    color: #065f46;
+}
+
+.balance-status.insufficient {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+/* ==================== Buttons ==================== */
+.btn-primary, .btn-secondary {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.btn-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.btn-secondary {
+    background: white;
+    color: #374151;
+    border: 1px solid #e5e7eb;
+}
+
+.btn-secondary:hover {
+    background: #f9fafb;
+}
+
+/* ==================== Recharge Content ==================== */
+.recharge-content h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 20px;
+}
+
+.recharge-method {
+    padding: 20px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
+
+.recharge-method h4 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 8px;
+}
+
+.recharge-method p {
+    font-size: 14px;
+    color: #6b7280;
+    margin-bottom: 12px;
+}
+
+.wallet-address {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.wallet-address code {
+    flex: 1;
+    padding: 10px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.btn-copy {
+    padding: 8px 16px;
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-copy:hover {
+    background: #5568d3;
+}
+
+/* ==================== History Tabs ==================== */
+.history-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.history-tab {
+    padding: 12px 24px;
+    border: none;
+    background: transparent;
+    font-size: 14px;
+    font-weight: 500;
+    color: #6b7280;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+}
+
+.history-tab:hover {
+    color: #374151;
+}
+
+.history-tab.active {
+    color: #667eea;
+    border-bottom-color: #667eea;
+}
+
+.history-tab-content {
+    display: none;
+}
+
+.history-tab-content.active {
+    display: block;
+}
+
+.history-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.history-table th {
+    padding: 12px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: #374151;
+    background: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.history-table td {
+    padding: 12px;
+    font-size: 14px;
+    color: #6b7280;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+/* ==================== Responsive Design ==================== */
+@media (max-width: 1200px) {
+    .dashboard-overview {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .plaza-header {
+        flex-direction: column;
+        gap: 16px;
+        padding: 16px;
+    }
+
+    .account-info {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dashboard-overview {
+        grid-template-columns: 1fr;
+    }
+
+    .wizard-steps {
+        flex-wrap: wrap;
+    }
+}

--- a/dist/css/ad_plaza.css
+++ b/dist/css/ad_plaza.css
@@ -1,4 +1,4 @@
-/* Ad Plaza CSS Styles */
+/* Ad Plaza Earn CSS Styles */
 
 /* ==================== Global Styles ==================== */
 * {
@@ -45,145 +45,85 @@ body {
     font-size: 28px;
 }
 
-.plaza-header-center {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-}
-
-.mode-switch {
-    display: inline-flex;
-    background: #f3f4f6;
-    border-radius: 12px;
-    padding: 4px;
-    gap: 4px;
-}
-
-.mode-btn {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 24px;
-    border: none;
-    background: transparent;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 15px;
-    font-weight: 500;
-    color: #6b7280;
-    transition: all 0.2s;
-}
-
-.mode-btn:hover {
-    color: #374151;
-}
-
-.mode-btn.active {
-    background: white;
-    color: #667eea;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.mode-icon {
-    font-size: 18px;
-}
-
 .plaza-header-right {
     flex: 0 0 auto;
-}
-
-.account-info {
     display: flex;
     align-items: center;
-    gap: 12px;
 }
 
-.account-balance {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 16px;
-    background: #f3f4f6;
-    border-radius: 8px;
-}
-
-.balance-label {
-    font-size: 14px;
-    color: #6b7280;
-}
-
-.balance-value {
-    font-size: 16px;
-    font-weight: 600;
-    color: #10b981;
-}
-
-.btn-recharge, .btn-history {
-    padding: 8px 16px;
+.btn-open-advertise {
+    padding: 10px 18px;
     border: none;
-    border-radius: 8px;
+    border-radius: 10px;
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s;
+    color: #fff;
+    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.25);
 }
 
-.btn-recharge {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-}
-
-.btn-recharge:hover {
+.btn-open-advertise:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-}
-
-.btn-history {
-    background: white;
-    color: #374151;
-    border: 1px solid #e5e7eb;
-}
-
-.btn-history:hover {
-    background: #f9fafb;
+    box-shadow: 0 6px 16px rgba(16, 185, 129, 0.35);
 }
 
 /* ==================== Plaza Views ==================== */
 .plaza-view {
-    display: none;
     padding: 32px;
     max-width: 1400px;
     margin: 0 auto;
 }
 
-.plaza-view.active {
-    display: block;
-}
-
-/* ==================== Earnings Overview (Earn Mode) ==================== */
-.earnings-overview {
+/* ==================== Earn Layout ==================== */
+.earn-layout {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 20px;
-    margin-bottom: 32px;
+    grid-template-columns: 320px 1fr;
+    gap: 24px;
+    align-items: start;
 }
 
-.overview-card {
+.earn-left {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.earn-right {
+    min-width: 0;
+}
+
+.withdraw-card {
     background: white;
     padding: 24px;
     border-radius: 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    transition: transform 0.2s;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
-.overview-card:hover {
-    transform: translateY(-2px);
+.withdraw-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.withdraw-status {
+    font-size: 12px;
+    color: #6b7280;
+    background: #f3f4f6;
+    padding: 4px 10px;
+    border-radius: 999px;
+    height: fit-content;
 }
 
 .card-label {
     font-size: 14px;
     color: #6b7280;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .card-value {
@@ -192,29 +132,30 @@ body {
     color: #10b981;
 }
 
-.btn-view-details {
-    width: 100%;
-    padding: 12px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.btn-view-details:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-}
-
-/* ==================== Ad List Container ==================== */
-.ad-list-container {
+.withdraw-actions {
     display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 24px;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.earn-summary {
+    display: grid;
+    gap: 10px;
+    background: #f9fafb;
+    border-radius: 10px;
+    padding: 12px;
+}
+
+.summary-item {
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    color: #4b5563;
+}
+
+.summary-value {
+    font-weight: 600;
+    color: #111827;
 }
 
 /* ==================== Filters Sidebar ==================== */
@@ -322,9 +263,6 @@ body {
     padding: 24px;
     border-radius: 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    height: fit-content;
-    position: sticky;
-    top: 100px;
 }
 
 .filter-title {
@@ -379,21 +317,6 @@ body {
 /* ==================== Ad Cards Grid ==================== */
 .ad-card-icon {
     font-size: 40px;
-}
-
-/* Make My Earnings feel like an action area, not a KPI card */
-.earnings-overview {
-    grid-template-columns: repeat(3, 1fr) 220px;
-    align-items: stretch;
-}
-
-.overview-actions {
-    display: flex;
-    align-items: stretch;
-}
-
-.overview-actions .btn-view-details {
-    height: 100%;
 }
 
 .ad-cards-grid {
@@ -593,415 +516,6 @@ body {
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
 }
 
-/* ==================== Dashboard Overview (Advertise Mode) ==================== */
-.dashboard-overview {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 20px;
-    margin-bottom: 32px;
-}
-
-.dashboard-card {
-    background: white;
-    padding: 24px;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    transition: transform 0.2s;
-}
-
-.dashboard-card:hover {
-    transform: translateY(-2px);
-}
-
-.dashboard-card .card-icon {
-    font-size: 36px;
-    flex-shrink: 0;
-}
-
-.dashboard-card .card-content {
-    flex: 1;
-}
-
-.dashboard-card .card-label {
-    font-size: 13px;
-    color: #6b7280;
-    margin-bottom: 4px;
-}
-
-.dashboard-card .card-value {
-    font-size: 24px;
-    font-weight: 700;
-    color: #374151;
-}
-
-.btn-card-action {
-    padding: 8px 16px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 13px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-    flex-shrink: 0;
-}
-
-.btn-card-action:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-}
-
-/* ==================== Publish Ad Section ==================== */
-.publish-ad-section {
-    margin-bottom: 32px;
-    text-align: center;
-}
-
-.btn-publish-ad {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 40px;
-    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
-    color: white;
-    border: none;
-    border-radius: 12px;
-    font-size: 16px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
-}
-
-.btn-publish-ad:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(16, 185, 129, 0.4);
-}
-
-.publish-icon {
-    font-size: 20px;
-}
-
-/* ==================== Sections ==================== */
-.my-ads-section, .spending-section {
-    margin-bottom: 32px;
-}
-
-.section-title {
-    font-size: 22px;
-    font-weight: 600;
-    color: #374151;
-    margin-bottom: 16px;
-}
-
-/* ==================== Tables ==================== */
-.ads-table-container, .spending-table-container {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    overflow: hidden;
-}
-
-.ads-table, .spending-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.ads-table thead, .spending-table thead {
-    background: #f9fafb;
-}
-
-.ads-table th, .spending-table th {
-    padding: 12px 16px;
-    text-align: left;
-    font-size: 13px;
-    font-weight: 600;
-    color: #374151;
-    border-bottom: 1px solid #e5e7eb;
-}
-
-.ads-table td, .spending-table td {
-    padding: 16px;
-    font-size: 14px;
-    color: #6b7280;
-    border-bottom: 1px solid #f3f4f6;
-}
-
-.ads-table tbody tr:hover, .spending-table tbody tr:hover {
-    background: #f9fafb;
-}
-
-.empty-row td {
-    text-align: center;
-    padding: 40px;
-}
-
-.empty-state-small {
-    color: #9ca3af;
-    font-size: 14px;
-}
-
-/* ==================== Modal Styles ==================== */
-.modal {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 1000;
-    align-items: center;
-    justify-content: center;
-    padding: 20px;
-}
-
-.modal.active {
-    display: flex;
-}
-
-.modal-dialog {
-    background: white;
-    border-radius: 16px;
-    width: 100%;
-    max-width: 600px;
-    max-height: 90vh;
-    overflow-y: auto;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-}
-
-.modal-large {
-    max-width: 900px;
-}
-
-.modal-wizard {
-    max-width: 700px;
-}
-
-.modal-header {
-    padding: 24px;
-    border-bottom: 1px solid #e5e7eb;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.modal-title {
-    font-size: 22px;
-    font-weight: 600;
-    color: #374151;
-}
-
-.btn-close {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    font-size: 24px;
-    color: #6b7280;
-    cursor: pointer;
-    border-radius: 6px;
-    transition: all 0.2s;
-}
-
-.btn-close:hover {
-    background: #f3f4f6;
-    color: #374151;
-}
-
-.modal-body {
-    padding: 24px;
-}
-
-.modal-footer {
-    padding: 24px;
-    border-top: 1px solid #e5e7eb;
-    display: flex;
-    gap: 12px;
-    justify-content: flex-end;
-}
-
-/* ==================== Wizard Steps ==================== */
-.wizard-steps {
-    display: flex;
-    justify-content: space-between;
-    padding: 24px 24px 0;
-    position: relative;
-}
-
-.wizard-steps::before {
-    content: '';
-    position: absolute;
-    top: 44px;
-    left: 24px;
-    right: 24px;
-    height: 2px;
-    background: #e5e7eb;
-    z-index: 0;
-}
-
-.wizard-step {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    flex: 1;
-    position: relative;
-    z-index: 1;
-}
-
-.step-number {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: #e5e7eb;
-    color: #9ca3af;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 600;
-    font-size: 16px;
-    transition: all 0.3s;
-}
-
-.wizard-step.active .step-number {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-}
-
-.wizard-step.completed .step-number {
-    background: #10b981;
-    color: white;
-}
-
-.step-label {
-    font-size: 12px;
-    color: #9ca3af;
-    font-weight: 500;
-}
-
-.wizard-step.active .step-label {
-    color: #667eea;
-}
-
-/* ==================== Wizard Content ==================== */
-.wizard-content {
-    display: none;
-}
-
-.wizard-content.active {
-    display: block;
-}
-
-.wizard-content h3 {
-    font-size: 18px;
-    font-weight: 600;
-    color: #374151;
-    margin-bottom: 20px;
-}
-
-/* ==================== Form Styles ==================== */
-.form-group {
-    margin-bottom: 20px;
-}
-
-.form-group label {
-    display: block;
-    font-size: 14px;
-    font-weight: 500;
-    color: #374151;
-    margin-bottom: 8px;
-}
-
-.form-input, .form-select, .form-textarea {
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    font-size: 14px;
-    transition: all 0.2s;
-}
-
-.form-input:focus, .form-select:focus, .form-textarea:focus {
-    outline: none;
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-}
-
-.form-hint {
-    display: block;
-    margin-top: 4px;
-    font-size: 12px;
-    color: #9ca3af;
-}
-
-/* ==================== Budget Summary ==================== */
-.budget-summary {
-    background: #f9fafb;
-    padding: 20px;
-    border-radius: 8px;
-    margin-bottom: 20px;
-}
-
-.summary-row {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px 0;
-    font-size: 14px;
-}
-
-.summary-row.total {
-    border-top: 2px solid #e5e7eb;
-    margin-top: 8px;
-    padding-top: 12px;
-    font-weight: 600;
-    font-size: 16px;
-}
-
-.summary-label {
-    color: #6b7280;
-}
-
-.summary-value {
-    color: #374151;
-    font-weight: 500;
-}
-
-/* ==================== Balance Check ==================== */
-.balance-check {
-    padding: 16px;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-}
-
-.balance-check-row {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 12px;
-    font-size: 14px;
-}
-
-.balance-status {
-    padding: 12px;
-    border-radius: 6px;
-    font-size: 14px;
-    text-align: center;
-}
-
-.balance-status.sufficient {
-    background: #d1fae5;
-    color: #065f46;
-}
-
-.balance-status.insufficient {
-    background: #fee2e2;
-    color: #991b1b;
-}
-
 /* ==================== Buttons ==================== */
 .btn-primary, .btn-secondary {
     padding: 10px 20px;
@@ -1039,137 +553,10 @@ body {
     background: #f9fafb;
 }
 
-/* ==================== Recharge Content ==================== */
-.recharge-content h3 {
-    font-size: 18px;
-    font-weight: 600;
-    color: #374151;
-    margin-bottom: 20px;
-}
-
-.recharge-method {
-    padding: 20px;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    margin-bottom: 16px;
-}
-
-.recharge-method h4 {
-    font-size: 16px;
-    font-weight: 600;
-    color: #374151;
-    margin-bottom: 8px;
-}
-
-.recharge-method p {
-    font-size: 14px;
-    color: #6b7280;
-    margin-bottom: 12px;
-}
-
-.wallet-address {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-}
-
-.wallet-address code {
-    flex: 1;
-    padding: 10px;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 6px;
-    font-size: 13px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.btn-copy {
-    padding: 8px 16px;
-    background: #667eea;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    font-size: 13px;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.btn-copy:hover {
-    background: #5568d3;
-}
-
-/* ==================== History Tabs ==================== */
-.history-tabs {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 20px;
-    border-bottom: 1px solid #e5e7eb;
-}
-
-.history-tab {
-    padding: 12px 24px;
-    border: none;
-    background: transparent;
-    font-size: 14px;
-    font-weight: 500;
-    color: #6b7280;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    transition: all 0.2s;
-}
-
-.history-tab:hover {
-    color: #374151;
-}
-
-.history-tab.active {
-    color: #667eea;
-    border-bottom-color: #667eea;
-}
-
-.history-tab-content {
-    display: none;
-}
-
-.history-tab-content.active {
-    display: block;
-}
-
-.history-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.history-table th {
-    padding: 12px;
-    text-align: left;
-    font-size: 13px;
-    font-weight: 600;
-    color: #374151;
-    background: #f9fafb;
-    border-bottom: 1px solid #e5e7eb;
-}
-
-.history-table td {
-    padding: 12px;
-    font-size: 14px;
-    color: #6b7280;
-    border-bottom: 1px solid #f3f4f6;
-}
-
 /* ==================== Responsive Design ==================== */
 @media (max-width: 1200px) {
-    .earnings-overview, .dashboard-overview {
-        grid-template-columns: repeat(2, 1fr);
-    }
-    
-    .ad-list-container {
+    .earn-layout {
         grid-template-columns: 1fr;
-    }
-    
-    .filters-sidebar {
-        position: static;
     }
 }
 
@@ -1179,30 +566,16 @@ body {
         gap: 16px;
         padding: 16px;
     }
-    
-    .plaza-header-center {
-        width: 100%;
-    }
-    
-    .mode-switch {
-        width: 100%;
-        justify-content: space-around;
-    }
-    
-    .account-info {
-        width: 100%;
-        justify-content: space-between;
-    }
-    
-    .earnings-overview, .dashboard-overview {
+
+    .earn-layout {
         grid-template-columns: 1fr;
     }
-    
+
+    .withdraw-actions {
+        grid-template-columns: 1fr;
+    }
+
     .ad-cards-grid {
         grid-template-columns: 1fr;
-    }
-    
-    .wizard-steps {
-        flex-wrap: wrap;
     }
 }

--- a/dist/html/ad_advertise.html
+++ b/dist/html/ad_advertise.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advertise - TweetCat</title>
+    <link rel="stylesheet" href="../css/common_utils.css"/>
+    <link rel="stylesheet" href="../css/ad_advertise.css"/>
+    <script src="../js/ad_advertise.js"></script>
+</head>
+<body>
+    <!-- Top Navigation -->
+    <header class="plaza-header">
+        <div class="plaza-header-left">
+            <div class="plaza-logo">
+                <span class="logo-icon">🏪</span>
+                <span class="logo-text">Advertise</span>
+            </div>
+        </div>
+
+        <div class="plaza-header-right">
+            <div class="account-info">
+                <div class="account-balance">
+                    <span class="balance-label">Balance:</span>
+                    <span class="balance-value">0.00 USDC</span>
+                </div>
+                <button id="btn-recharge" class="btn-recharge">Recharge</button>
+                <button id="btn-history" class="btn-history">History</button>
+            </div>
+        </div>
+    </header>
+
+    <div id="view-advertise" class="plaza-view active">
+        <!-- Dashboard Cards -->
+        <div class="dashboard-overview">
+            <div class="dashboard-card">
+                <div class="card-icon">💳</div>
+                <div class="card-content">
+                    <div class="card-label">Ad Account Balance</div>
+                    <div class="card-value">0.00 USDC</div>
+                </div>
+                <button id="btn-recharge-dashboard" class="btn-card-action">Recharge</button>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-icon">📊</div>
+                <div class="card-content">
+                    <div class="card-label">Active Ads</div>
+                    <div class="card-value">0</div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-icon">📉</div>
+                <div class="card-content">
+                    <div class="card-label">Today's Spend</div>
+                    <div class="card-value">0.00 USDC</div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-icon">📈</div>
+                <div class="card-content">
+                    <div class="card-label">This Week's Spend</div>
+                    <div class="card-value">0.00 USDC</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Publish Ad Button -->
+        <div class="publish-ad-section">
+            <button id="btn-publish-ad" class="btn-publish-ad">
+                <span class="publish-icon">➕</span>
+                <span class="publish-text">Publish New Ad</span>
+            </button>
+        </div>
+
+        <!-- My Ads List -->
+        <div class="my-ads-section">
+            <h2 class="section-title">My Ads</h2>
+            <div class="ads-table-container">
+                <table class="ads-table">
+                    <thead>
+                        <tr>
+                            <th>Ad Name</th>
+                            <th>Status</th>
+                            <th>Reward per Task</th>
+                            <th>Completed</th>
+                            <th>Spent</th>
+                            <th>Remaining Budget</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="my-ads-tbody">
+                        <tr class="empty-row">
+                            <td colspan="7">
+                                <div class="empty-state-small">
+                                    <p>No ads published yet. Click "Publish New Ad" to get started!</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Recent Spending -->
+        <div class="spending-section">
+            <h2 class="section-title">Recent Spending</h2>
+            <div class="spending-table-container">
+                <table class="spending-table">
+                    <thead>
+                        <tr>
+                            <th>Time</th>
+                            <th>Ad</th>
+                            <th>Event</th>
+                            <th>Amount</th>
+                            <th>Service Fee</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody id="spending-tbody">
+                        <tr class="empty-row">
+                            <td colspan="6">
+                                <div class="empty-state-small">
+                                    <p>No spending records yet.</p>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Publish Ad Wizard Modal -->
+    <div id="publish-wizard-modal" class="modal">
+        <div class="modal-dialog modal-wizard">
+            <div class="modal-header">
+                <h2 class="modal-title">Publish New Ad</h2>
+                <button id="close-wizard" class="btn-close">✕</button>
+            </div>
+
+            <!-- Wizard Steps Indicator -->
+            <div class="wizard-steps">
+                <div class="wizard-step active" data-step="1">
+                    <div class="step-number">1</div>
+                    <div class="step-label">Basic Info</div>
+                </div>
+                <div class="wizard-step" data-step="2">
+                    <div class="step-number">2</div>
+                    <div class="step-label">Creative</div>
+                </div>
+                <div class="wizard-step" data-step="3">
+                    <div class="step-number">3</div>
+                    <div class="step-label">Task & Reward</div>
+                </div>
+                <div class="wizard-step" data-step="4">
+                    <div class="step-number">4</div>
+                    <div class="step-label">Budget</div>
+                </div>
+            </div>
+
+            <div class="modal-body">
+                <!-- Step 1: Basic Info -->
+                <div class="wizard-content active" data-step="1">
+                    <h3>Basic Information</h3>
+                    <div class="form-group">
+                        <label for="ad-name">Ad Name (for your reference)</label>
+                        <input type="text" id="ad-name" class="form-input" placeholder="e.g., Twitter Follow Campaign" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="ad-type">Ad Type</label>
+                        <select id="ad-type" class="form-select" required>
+                            <option value="">Select type...</option>
+                            <option value="traffic">Traffic</option>
+                            <option value="follow">Follow/Subscribe</option>
+                            <option value="register">Registration</option>
+                            <option value="download">Download</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="ad-category">Category</label>
+                        <select id="ad-category" class="form-select" required>
+                            <option value="">Select category...</option>
+                            <option value="follow">Follow</option>
+                            <option value="visit">Visit</option>
+                            <option value="register">Register</option>
+                            <option value="share">Share</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!-- Step 2: Creative -->
+                <div class="wizard-content" data-step="2">
+                    <h3>Creative Materials</h3>
+                    <div class="form-group">
+                        <label for="ad-title">Ad Title</label>
+                        <input type="text" id="ad-title" class="form-input" placeholder="e.g., Follow us on Twitter!" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="ad-description">Description</label>
+                        <textarea id="ad-description" class="form-textarea" rows="3" placeholder="Describe what users need to do..." required></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="ad-image">Ad Image/Icon (optional)</label>
+                        <input type="file" id="ad-image" class="form-input" accept="image/*">
+                        <small class="form-hint">Recommended: 300x300px, max 2MB</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="ad-url">Landing Page URL</label>
+                        <input type="url" id="ad-url" class="form-input" placeholder="https://..." required>
+                    </div>
+                </div>
+
+                <!-- Step 3: Task & Reward -->
+                <div class="wizard-content" data-step="3">
+                    <h3>Task Settings & Reward</h3>
+                    <div class="form-group">
+                        <label for="task-action">User Action Required</label>
+                        <select id="task-action" class="form-select" required>
+                            <option value="">Select action...</option>
+                            <option value="visit">Visit page</option>
+                            <option value="click">Click button</option>
+                            <option value="follow">Follow account</option>
+                            <option value="register">Register account</option>
+                            <option value="share">Share content</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="reward-amount">Reward per Task (USDC)</label>
+                        <input type="number" id="reward-amount" class="form-input" min="0.01" step="0.01" placeholder="0.50" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="task-limit">Total Task Limit</label>
+                        <input type="number" id="task-limit" class="form-input" min="1" placeholder="500" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="start-time">Start Time</label>
+                        <input type="datetime-local" id="start-time" class="form-input">
+                    </div>
+                    <div class="form-group">
+                        <label for="end-time">End Time</label>
+                        <input type="datetime-local" id="end-time" class="form-input">
+                    </div>
+                </div>
+
+                <!-- Step 4: Budget -->
+                <div class="wizard-content" data-step="4">
+                    <h3>Budget & Confirmation</h3>
+                    <div class="budget-summary">
+                        <div class="summary-row">
+                            <span class="summary-label">Reward per Task:</span>
+                            <span class="summary-value" id="summary-reward">0.00 USDC</span>
+                        </div>
+                        <div class="summary-row">
+                            <span class="summary-label">Total Tasks:</span>
+                            <span class="summary-value" id="summary-tasks">0</span>
+                        </div>
+                        <div class="summary-row">
+                            <span class="summary-label">Platform Fee (5%):</span>
+                            <span class="summary-value" id="summary-fee">0.00 USDC</span>
+                        </div>
+                        <div class="summary-row total">
+                            <span class="summary-label">Total Budget:</span>
+                            <span class="summary-value" id="summary-total">0.00 USDC</span>
+                        </div>
+                    </div>
+                    <div class="balance-check">
+                        <div class="balance-check-row">
+                            <span>Current Balance:</span>
+                            <span id="current-balance">0.00 USDC</span>
+                        </div>
+                        <div class="balance-status" id="balance-status">
+                            <!-- Will be updated by JS -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <button id="btn-wizard-prev" class="btn-secondary" style="display: none;">Previous</button>
+                <button id="btn-wizard-next" class="btn-primary">Next</button>
+                <button id="btn-wizard-submit" class="btn-primary" style="display: none;">Publish Ad</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Recharge Modal -->
+    <div id="recharge-modal" class="modal">
+        <div class="modal-dialog">
+            <div class="modal-header">
+                <h2 class="modal-title">Recharge Account</h2>
+                <button id="close-recharge" class="btn-close">✕</button>
+            </div>
+            <div class="modal-body">
+                <div class="recharge-content">
+                    <h3>Recharge Methods</h3>
+                    <div class="recharge-method">
+                        <h4>Transfer USDC</h4>
+                        <p>Transfer USDC to your wallet address:</p>
+                        <div class="wallet-address">
+                            <code id="wallet-address-display">Loading...</code>
+                            <button id="copy-address" class="btn-copy">Copy</button>
+                        </div>
+                    </div>
+                    <div class="recharge-method">
+                        <h4>Buy with Card</h4>
+                        <p>Purchase USDC directly with credit card or Apple Pay</p>
+                        <button id="btn-buy-card" class="btn-primary">Buy USDC</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- History Modal -->
+    <div id="history-modal" class="modal">
+        <div class="modal-dialog modal-large">
+            <div class="modal-header">
+                <h2 class="modal-title">Transaction History</h2>
+                <button id="close-history" class="btn-close">✕</button>
+            </div>
+            <div class="modal-body">
+                <div class="history-tabs">
+                    <button class="history-tab active" data-tab="earnings">Earnings</button>
+                    <button class="history-tab" data-tab="spending">Spending</button>
+                    <button class="history-tab" data-tab="recharge">Recharge</button>
+                </div>
+                <div class="history-content">
+                    <div class="history-tab-content active" data-tab="earnings">
+                        <table class="history-table">
+                            <thead>
+                                <tr>
+                                    <th>Time</th>
+                                    <th>Ad</th>
+                                    <th>Amount</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="empty-row">
+                                    <td colspan="4">No earnings yet</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="history-tab-content" data-tab="spending">
+                        <table class="history-table">
+                            <thead>
+                                <tr>
+                                    <th>Time</th>
+                                    <th>Ad</th>
+                                    <th>Amount</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="empty-row">
+                                    <td colspan="4">No spending yet</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="history-tab-content" data-tab="recharge">
+                        <table class="history-table">
+                            <thead>
+                                <tr>
+                                    <th>Time</th>
+                                    <th>Method</th>
+                                    <th>Amount</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="empty-row">
+                                    <td colspan="4">No recharge records</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ==================== Hidden Templates (for TS clone) ==================== -->
+    <template id="tpl-my-ad-row">
+        <tr class="my-ad-row" data-ad-id="">
+            <td class="td-name"></td>
+            <td class="td-status"></td>
+            <td class="td-reward"></td>
+            <td class="td-completed"></td>
+            <td class="td-spent"></td>
+            <td class="td-remaining"></td>
+            <td class="td-actions">
+                <button class="btn-secondary btn-view" type="button">View</button>
+                <button class="btn-secondary btn-toggle" type="button">Pause</button>
+            </td>
+        </tr>
+    </template>
+
+    <template id="tpl-empty-my-ads-row">
+        <tr class="empty-row">
+            <td colspan="7">
+                <div class="empty-state-small">
+                    <p>No ads published yet. Click "Publish New Ad" to get started!</p>
+                </div>
+            </td>
+        </tr>
+    </template>
+
+    <template id="tpl-spend-row">
+        <tr class="spend-row" data-id="">
+            <td class="td-time"></td>
+            <td class="td-ad"></td>
+            <td class="td-event"></td>
+            <td class="td-amount"></td>
+            <td class="td-fee"></td>
+            <td class="td-status"></td>
+        </tr>
+    </template>
+
+    <template id="tpl-empty-spend-row">
+        <tr class="empty-row">
+            <td colspan="6">
+                <div class="empty-state-small">
+                    <p>No spending records yet.</p>
+                </div>
+            </td>
+        </tr>
+    </template>
+
+    <template id="tpl-history-row">
+        <tr class="history-row">
+            <td class="td-time"></td>
+            <td class="td-name"></td>
+            <td class="td-amount"></td>
+            <td class="td-status"></td>
+        </tr>
+    </template>
+
+    <template id="tpl-empty-history-row">
+        <tr class="empty-row">
+            <td colspan="4" class="td-empty">No records</td>
+        </tr>
+    </template>
+</body>
+</html>

--- a/dist/html/ad_plaza.html
+++ b/dist/html/ad_plaza.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ad Plaza - TweetCat</title>
+    <title>Ad Plaza - Earn - TweetCat</title>
     <link rel="stylesheet" href="../css/common_utils.css"/>
     <link rel="stylesheet" href="../css/ad_plaza.css"/>
     <script src="../js/ad_plaza.js"></script>
@@ -17,518 +17,156 @@
                 <span class="logo-text">Ad Plaza</span>
             </div>
         </div>
-        
-        <div class="plaza-header-center">
-            <div class="mode-switch">
-                <button id="mode-earn" class="mode-btn active" data-mode="earn">
-                    <span class="mode-icon">💰</span>
-                    <span class="mode-text">Earn USDC</span>
-                </button>
-                <button id="mode-advertise" class="mode-btn" data-mode="advertise">
-                    <span class="mode-icon">📢</span>
-                    <span class="mode-text">Advertise</span>
-                </button>
-            </div>
-        </div>
-        
+
         <div class="plaza-header-right">
-            <div class="account-info">
-                <div class="account-balance">
-                    <span class="balance-label">Balance:</span>
-                    <span class="balance-value">0.00 USDC</span>
-                </div>
-                <button id="btn-recharge" class="btn-recharge">Recharge</button>
-                <button id="btn-history" class="btn-history">History</button>
-            </div>
+            <button id="btn-open-advertise" class="btn-open-advertise">Publish Ad / Advertise</button>
         </div>
     </header>
 
     <!-- Earn Mode View -->
     <div id="view-earn" class="plaza-view active">
-        <!-- Earnings Overview -->
-        <div class="earnings-overview">
-            <div class="overview-card">
-                <div class="card-label">Total Earned</div>
-                <div class="card-value">0.00 USDC</div>
-            </div>
-            <div class="overview-card">
-                <div class="card-label">Today Earned</div>
-                <div class="card-value">0.00 USDC</div>
-            </div>
-            <div class="overview-card">
-                <div class="card-label">Pending</div>
-                <div class="card-value">0.00 USDC</div>
-            </div>
-            <div class="overview-actions">
-                <button id="btn-my-earnings" class="btn-view-details">My Earnings</button>
-            </div>
-        </div>
+        <div class="earn-layout">
+            <aside class="earn-left">
+                <section class="withdraw-card">
+                    <div class="withdraw-card-header">
+                        <div>
+                            <div class="card-label">Withdrawable</div>
+                            <div class="card-value" id="withdrawable-amount">0.00 USDC</div>
+                        </div>
+                        <span class="withdraw-status">Updated today</span>
+                    </div>
+                    <div class="withdraw-actions">
+                        <button id="btn-withdraw" class="btn-primary">Withdraw</button>
+                        <button id="btn-earn-activity" class="btn-secondary">Activity</button>
+                    </div>
+                    <div class="earn-summary">
+                        <div class="summary-item">
+                            <span class="summary-label">Total Earned</span>
+                            <span class="summary-value" id="total-earned">0.00 USDC</span>
+                        </div>
+                        <div class="summary-item">
+                            <span class="summary-label">Today Earned</span>
+                            <span class="summary-value" id="today-earned">0.00 USDC</span>
+                        </div>
+                        <div class="summary-item">
+                            <span class="summary-label">Pending</span>
+                            <span class="summary-value" id="pending-earned">0.00 USDC</span>
+                        </div>
+                    </div>
+                </section>
 
-        <!-- Ad List Container -->
-        <div class="ad-list-container">
-            <!-- Filters Sidebar -->
-            <aside class="filters-sidebar">
-                <h3 class="filter-title">Filters</h3>
+                <div class="filters-sidebar">
+                    <h3 class="filter-title">Filters</h3>
 
-                <!-- Search + Clear (Filters tools) -->
-                <div class="filter-tools">
-                    <div class="filter-search" role="search">
-                        <span class="filter-search-icon">🔎</span>
-                        <input
-                                id="ad-search"
-                                class="filter-search-input"
-                                type="search"
-                                placeholder="Search ads..."
-                                autocomplete="off"
-                                spellcheck="false"
-                        />
-                        <button id="btn-clear-search" class="filter-search-clear" type="button" aria-label="Clear search">✕</button>
+                    <!-- Search + Clear (Filters tools) -->
+                    <div class="filter-tools">
+                        <div class="filter-search" role="search">
+                            <span class="filter-search-icon">🔎</span>
+                            <input
+                                    id="ad-search"
+                                    class="filter-search-input"
+                                    type="search"
+                                    placeholder="Search ads..."
+                                    autocomplete="off"
+                                    spellcheck="false"
+                            />
+                            <button id="btn-clear-search" class="filter-search-clear" type="button" aria-label="Clear search">✕</button>
+                        </div>
+
+                        <button id="btn-clear-filters" class="btn-clear-filters" type="button" disabled>
+                            Clear filters
+                        </button>
                     </div>
 
-                    <button id="btn-clear-filters" class="btn-clear-filters" type="button" disabled>
-                        Clear filters
-                    </button>
-                </div>
+                    <div class="filter-group">
+                        <h4 class="filter-group-title">Category</h4>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="category" value="follow" checked>
+                            <span>Follow</span>
+                        </label>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="category" value="visit" checked>
+                            <span>Visit</span>
+                        </label>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="category" value="register" checked>
+                            <span>Register</span>
+                        </label>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="category" value="share" checked>
+                            <span>Share</span>
+                        </label>
+                    </div>
 
-                <div class="filter-group">
-                    <h4 class="filter-group-title">Category</h4>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="category" value="follow" checked>
-                        <span>Follow</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="category" value="visit" checked>
-                        <span>Visit</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="category" value="register" checked>
-                        <span>Register</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="category" value="share" checked>
-                        <span>Share</span>
-                    </label>
-                </div>
+                    <div class="filter-group">
+                        <h4 class="filter-group-title">Reward Range</h4>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="reward" value="0.1-0.5" checked>
+                            <span>0.1 - 0.5 USDC</span>
+                        </label>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="reward" value="0.5-1" checked>
+                            <span>0.5 - 1.0 USDC</span>
+                        </label>
+                        <label class="filter-checkbox">
+                            <input type="checkbox" name="reward" value="1+" checked>
+                            <span>1.0+ USDC</span>
+                        </label>
+                    </div>
 
-                <div class="filter-group">
-                    <h4 class="filter-group-title">Reward Range</h4>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="reward" value="0.1-0.5" checked>
-                        <span>0.1 - 0.5 USDC</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="reward" value="0.5-1" checked>
-                        <span>0.5 - 1.0 USDC</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" name="reward" value="1+" checked>
-                        <span>1.0+ USDC</span>
-                    </label>
-                </div>
-
-                <div class="filter-group">
-                    <h4 class="filter-group-title">Sort By</h4>
-                    <select id="sort-select" class="filter-select">
-                        <option value="reward-high">Highest Reward</option>
-                        <option value="newest">Newest</option>
-                        <option value="time-short">Shortest Time</option>
-                        <option value="popular">Most Popular</option>
-                    </select>
+                    <div class="filter-group">
+                        <h4 class="filter-group-title">Sort By</h4>
+                        <select id="sort-select" class="filter-select">
+                            <option value="reward-high">Highest Reward</option>
+                            <option value="newest">Newest</option>
+                            <option value="time-short">Shortest Time</option>
+                            <option value="popular">Most Popular</option>
+                        </select>
+                    </div>
                 </div>
             </aside>
 
-            <!-- Ad Cards Grid -->
-            <main class="ad-cards-grid">
-                <div class="empty-state">
-                    <div class="empty-icon">📭</div>
-                    <h3>No Ads Available</h3>
-                    <p>Check back later for new earning opportunities!</p>
+            <main class="earn-right">
+                <div class="ad-cards-grid">
+                    <div class="empty-state">
+                        <div class="empty-icon">📭</div>
+                        <h3>No Ads Available</h3>
+                        <p>Check back later for new earning opportunities!</p>
+                    </div>
+
+                    <!-- Example Ad Card (will be dynamically generated) -->
+                    <!-- 
+                    <div class="ad-card">
+                        <div class="ad-card-image">
+                            <img src="placeholder.jpg" alt="Ad">
+                        </div>
+                        <div class="ad-card-content">
+                            <div class="ad-card-header">
+                                <h3 class="ad-card-title">Follow Twitter Account</h3>
+                                <div class="ad-card-brand">@BrandName</div>
+                            </div>
+                            <p class="ad-card-description">Follow our Twitter account and earn rewards instantly!</p>
+                            <div class="ad-card-meta">
+                                <span class="meta-item">⏱️ 2 min</span>
+                                <span class="meta-item">👥 120/500</span>
+                                <span class="meta-item">📅 Ends: Jan 30</span>
+                            </div>
+                            <div class="ad-card-tags">
+                                <span class="tag tag-new">New</span>
+                                <span class="tag tag-easy">Easy</span>
+                            </div>
+                        </div>
+                        <div class="ad-card-footer">
+                            <div class="ad-card-reward">
+                                <span class="reward-label">Earn:</span>
+                                <span class="reward-value">0.50 USDC</span>
+                            </div>
+                            <button class="btn-start-task">Start Task</button>
+                        </div>
+                    </div>
+                    -->
                 </div>
-                
-                <!-- Example Ad Card (will be dynamically generated) -->
-                <!-- 
-                <div class="ad-card">
-                    <div class="ad-card-image">
-                        <img src="placeholder.jpg" alt="Ad">
-                    </div>
-                    <div class="ad-card-content">
-                        <div class="ad-card-header">
-                            <h3 class="ad-card-title">Follow Twitter Account</h3>
-                            <div class="ad-card-brand">@BrandName</div>
-                        </div>
-                        <p class="ad-card-description">Follow our Twitter account and earn rewards instantly!</p>
-                        <div class="ad-card-meta">
-                            <span class="meta-item">⏱️ 2 min</span>
-                            <span class="meta-item">👥 120/500</span>
-                            <span class="meta-item">📅 Ends: Jan 30</span>
-                        </div>
-                        <div class="ad-card-tags">
-                            <span class="tag tag-new">New</span>
-                            <span class="tag tag-easy">Easy</span>
-                        </div>
-                    </div>
-                    <div class="ad-card-footer">
-                        <div class="ad-card-reward">
-                            <span class="reward-label">Earn:</span>
-                            <span class="reward-value">0.50 USDC</span>
-                        </div>
-                        <button class="btn-start-task">Start Task</button>
-                    </div>
-                </div>
-                -->
             </main>
-        </div>
-    </div>
-
-    <!-- Advertise Mode View -->
-    <div id="view-advertise" class="plaza-view">
-        <!-- Dashboard Cards -->
-        <div class="dashboard-overview">
-            <div class="dashboard-card">
-                <div class="card-icon">💳</div>
-                <div class="card-content">
-                    <div class="card-label">Ad Account Balance</div>
-                    <div class="card-value">0.00 USDC</div>
-                </div>
-                <button id="btn-recharge-dashboard" class="btn-card-action">Recharge</button>
-            </div>
-            <div class="dashboard-card">
-                <div class="card-icon">📊</div>
-                <div class="card-content">
-                    <div class="card-label">Active Ads</div>
-                    <div class="card-value">0</div>
-                </div>
-            </div>
-            <div class="dashboard-card">
-                <div class="card-icon">📉</div>
-                <div class="card-content">
-                    <div class="card-label">Today's Spend</div>
-                    <div class="card-value">0.00 USDC</div>
-                </div>
-            </div>
-            <div class="dashboard-card">
-                <div class="card-icon">📈</div>
-                <div class="card-content">
-                    <div class="card-label">This Week's Spend</div>
-                    <div class="card-value">0.00 USDC</div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Publish Ad Button -->
-        <div class="publish-ad-section">
-            <button id="btn-publish-ad" class="btn-publish-ad">
-                <span class="publish-icon">➕</span>
-                <span class="publish-text">Publish New Ad</span>
-            </button>
-        </div>
-
-        <!-- My Ads List -->
-        <div class="my-ads-section">
-            <h2 class="section-title">My Ads</h2>
-            <div class="ads-table-container">
-                <table class="ads-table">
-                    <thead>
-                        <tr>
-                            <th>Ad Name</th>
-                            <th>Status</th>
-                            <th>Reward per Task</th>
-                            <th>Completed</th>
-                            <th>Spent</th>
-                            <th>Remaining Budget</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody id="my-ads-tbody">
-                        <tr class="empty-row">
-                            <td colspan="7">
-                                <div class="empty-state-small">
-                                    <p>No ads published yet. Click "Publish New Ad" to get started!</p>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <!-- Recent Spending -->
-        <div class="spending-section">
-            <h2 class="section-title">Recent Spending</h2>
-            <div class="spending-table-container">
-                <table class="spending-table">
-                    <thead>
-                        <tr>
-                            <th>Time</th>
-                            <th>Ad</th>
-                            <th>Event</th>
-                            <th>Amount</th>
-                            <th>Service Fee</th>
-                            <th>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody id="spending-tbody">
-                        <tr class="empty-row">
-                            <td colspan="6">
-                                <div class="empty-state-small">
-                                    <p>No spending records yet.</p>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-
-    <!-- Publish Ad Wizard Modal -->
-    <div id="publish-wizard-modal" class="modal">
-        <div class="modal-dialog modal-wizard">
-            <div class="modal-header">
-                <h2 class="modal-title">Publish New Ad</h2>
-                <button id="close-wizard" class="btn-close">✕</button>
-            </div>
-            
-            <!-- Wizard Steps Indicator -->
-            <div class="wizard-steps">
-                <div class="wizard-step active" data-step="1">
-                    <div class="step-number">1</div>
-                    <div class="step-label">Basic Info</div>
-                </div>
-                <div class="wizard-step" data-step="2">
-                    <div class="step-number">2</div>
-                    <div class="step-label">Creative</div>
-                </div>
-                <div class="wizard-step" data-step="3">
-                    <div class="step-number">3</div>
-                    <div class="step-label">Task & Reward</div>
-                </div>
-                <div class="wizard-step" data-step="4">
-                    <div class="step-number">4</div>
-                    <div class="step-label">Budget</div>
-                </div>
-            </div>
-
-            <div class="modal-body">
-                <!-- Step 1: Basic Info -->
-                <div class="wizard-content active" data-step="1">
-                    <h3>Basic Information</h3>
-                    <div class="form-group">
-                        <label for="ad-name">Ad Name (for your reference)</label>
-                        <input type="text" id="ad-name" class="form-input" placeholder="e.g., Twitter Follow Campaign" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="ad-type">Ad Type</label>
-                        <select id="ad-type" class="form-select" required>
-                            <option value="">Select type...</option>
-                            <option value="traffic">Traffic</option>
-                            <option value="follow">Follow/Subscribe</option>
-                            <option value="register">Registration</option>
-                            <option value="download">Download</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label for="ad-category">Category</label>
-                        <select id="ad-category" class="form-select" required>
-                            <option value="">Select category...</option>
-                            <option value="follow">Follow</option>
-                            <option value="visit">Visit</option>
-                            <option value="register">Register</option>
-                            <option value="share">Share</option>
-                        </select>
-                    </div>
-                </div>
-
-                <!-- Step 2: Creative -->
-                <div class="wizard-content" data-step="2">
-                    <h3>Creative Materials</h3>
-                    <div class="form-group">
-                        <label for="ad-title">Ad Title</label>
-                        <input type="text" id="ad-title" class="form-input" placeholder="e.g., Follow us on Twitter!" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="ad-description">Description</label>
-                        <textarea id="ad-description" class="form-textarea" rows="3" placeholder="Describe what users need to do..." required></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="ad-image">Ad Image/Icon (optional)</label>
-                        <input type="file" id="ad-image" class="form-input" accept="image/*">
-                        <small class="form-hint">Recommended: 300x300px, max 2MB</small>
-                    </div>
-                    <div class="form-group">
-                        <label for="ad-url">Landing Page URL</label>
-                        <input type="url" id="ad-url" class="form-input" placeholder="https://..." required>
-                    </div>
-                </div>
-
-                <!-- Step 3: Task & Reward -->
-                <div class="wizard-content" data-step="3">
-                    <h3>Task Settings & Reward</h3>
-                    <div class="form-group">
-                        <label for="task-action">User Action Required</label>
-                        <select id="task-action" class="form-select" required>
-                            <option value="">Select action...</option>
-                            <option value="visit">Visit page</option>
-                            <option value="click">Click button</option>
-                            <option value="follow">Follow account</option>
-                            <option value="register">Register account</option>
-                            <option value="share">Share content</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label for="reward-amount">Reward per Task (USDC)</label>
-                        <input type="number" id="reward-amount" class="form-input" min="0.01" step="0.01" placeholder="0.50" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="task-limit">Total Task Limit</label>
-                        <input type="number" id="task-limit" class="form-input" min="1" placeholder="500" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="start-time">Start Time</label>
-                        <input type="datetime-local" id="start-time" class="form-input">
-                    </div>
-                    <div class="form-group">
-                        <label for="end-time">End Time</label>
-                        <input type="datetime-local" id="end-time" class="form-input">
-                    </div>
-                </div>
-
-                <!-- Step 4: Budget -->
-                <div class="wizard-content" data-step="4">
-                    <h3>Budget & Confirmation</h3>
-                    <div class="budget-summary">
-                        <div class="summary-row">
-                            <span class="summary-label">Reward per Task:</span>
-                            <span class="summary-value" id="summary-reward">0.00 USDC</span>
-                        </div>
-                        <div class="summary-row">
-                            <span class="summary-label">Total Tasks:</span>
-                            <span class="summary-value" id="summary-tasks">0</span>
-                        </div>
-                        <div class="summary-row">
-                            <span class="summary-label">Platform Fee (5%):</span>
-                            <span class="summary-value" id="summary-fee">0.00 USDC</span>
-                        </div>
-                        <div class="summary-row total">
-                            <span class="summary-label">Total Budget:</span>
-                            <span class="summary-value" id="summary-total">0.00 USDC</span>
-                        </div>
-                    </div>
-                    <div class="balance-check">
-                        <div class="balance-check-row">
-                            <span>Current Balance:</span>
-                            <span id="current-balance">0.00 USDC</span>
-                        </div>
-                        <div class="balance-status" id="balance-status">
-                            <!-- Will be updated by JS -->
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="modal-footer">
-                <button id="btn-wizard-prev" class="btn-secondary" style="display: none;">Previous</button>
-                <button id="btn-wizard-next" class="btn-primary">Next</button>
-                <button id="btn-wizard-submit" class="btn-primary" style="display: none;">Publish Ad</button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Recharge Modal -->
-    <div id="recharge-modal" class="modal">
-        <div class="modal-dialog">
-            <div class="modal-header">
-                <h2 class="modal-title">Recharge Account</h2>
-                <button id="close-recharge" class="btn-close">✕</button>
-            </div>
-            <div class="modal-body">
-                <div class="recharge-content">
-                    <h3>Recharge Methods</h3>
-                    <div class="recharge-method">
-                        <h4>Transfer USDC</h4>
-                        <p>Transfer USDC to your wallet address:</p>
-                        <div class="wallet-address">
-                            <code id="wallet-address-display">Loading...</code>
-                            <button id="copy-address" class="btn-copy">Copy</button>
-                        </div>
-                    </div>
-                    <div class="recharge-method">
-                        <h4>Buy with Card</h4>
-                        <p>Purchase USDC directly with credit card or Apple Pay</p>
-                        <button id="btn-buy-card" class="btn-primary">Buy USDC</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- History Modal -->
-    <div id="history-modal" class="modal">
-        <div class="modal-dialog modal-large">
-            <div class="modal-header">
-                <h2 class="modal-title">Transaction History</h2>
-                <button id="close-history" class="btn-close">✕</button>
-            </div>
-            <div class="modal-body">
-                <div class="history-tabs">
-                    <button class="history-tab active" data-tab="earnings">Earnings</button>
-                    <button class="history-tab" data-tab="spending">Spending</button>
-                    <button class="history-tab" data-tab="recharge">Recharge</button>
-                </div>
-                <div class="history-content">
-                    <div class="history-tab-content active" data-tab="earnings">
-                        <table class="history-table">
-                            <thead>
-                                <tr>
-                                    <th>Time</th>
-                                    <th>Ad</th>
-                                    <th>Amount</th>
-                                    <th>Status</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr class="empty-row">
-                                    <td colspan="4">No earnings yet</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="history-tab-content" data-tab="spending">
-                        <table class="history-table">
-                            <thead>
-                                <tr>
-                                    <th>Time</th>
-                                    <th>Ad</th>
-                                    <th>Amount</th>
-                                    <th>Status</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr class="empty-row">
-                                    <td colspan="4">No spending yet</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="history-tab-content" data-tab="recharge">
-                        <table class="history-table">
-                            <thead>
-                                <tr>
-                                    <th>Time</th>
-                                    <th>Method</th>
-                                    <th>Amount</th>
-                                    <th>Status</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr class="empty-row">
-                                    <td colspan="4">No recharge records</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 
@@ -568,68 +206,6 @@
             </div>
         </div>
     </template>
-
-    <template id="tpl-my-ad-row">
-        <tr class="my-ad-row" data-ad-id="">
-            <td class="td-name"></td>
-            <td class="td-status"></td>
-            <td class="td-reward"></td>
-            <td class="td-completed"></td>
-            <td class="td-spent"></td>
-            <td class="td-remaining"></td>
-            <td class="td-actions">
-                <button class="btn-secondary btn-view" type="button">View</button>
-                <button class="btn-secondary btn-toggle" type="button">Pause</button>
-            </td>
-        </tr>
-    </template>
-
-    <template id="tpl-empty-my-ads-row">
-        <tr class="empty-row">
-            <td colspan="7">
-                <div class="empty-state-small">
-                    <p>No ads published yet. Click "Publish New Ad" to get started!</p>
-                </div>
-            </td>
-        </tr>
-    </template>
-
-    <template id="tpl-spend-row">
-        <tr class="spend-row" data-id="">
-            <td class="td-time"></td>
-            <td class="td-ad"></td>
-            <td class="td-event"></td>
-            <td class="td-amount"></td>
-            <td class="td-fee"></td>
-            <td class="td-status"></td>
-        </tr>
-    </template>
-
-    <template id="tpl-empty-spend-row">
-        <tr class="empty-row">
-            <td colspan="6">
-                <div class="empty-state-small">
-                    <p>No spending records yet.</p>
-                </div>
-            </td>
-        </tr>
-    </template>
-
-    <template id="tpl-history-row">
-        <tr class="history-row">
-            <td class="td-time"></td>
-            <td class="td-name"></td>
-            <td class="td-amount"></td>
-            <td class="td-status"></td>
-        </tr>
-    </template>
-
-    <template id="tpl-empty-history-row">
-        <tr class="empty-row">
-            <td colspan="4" class="td-empty">No records</td>
-        </tr>
-    </template>
-
 
 </body>
 </html>

--- a/src/popup/ad_advertise.ts
+++ b/src/popup/ad_advertise.ts
@@ -1,0 +1,498 @@
+// ad_advertise.ts
+// 用假数据驱动 Advertise 页面的界面和按钮交互
+// ✅ 已移除所有 document.createElement：全部改为 HTML <template> + cloneNode
+
+// ========= 类型定义 =========
+
+type AdStatus = "Active" | "Paused" | "Ended" | "Balance Low";
+
+interface MyAdRow {
+    id: string;
+    name: string;
+    status: AdStatus;
+    rewardPerTask: number;
+    completed: number;
+    spent: number;
+    remainingBudget: number;
+}
+
+interface SpendRecord {
+    id: string;
+    time: string;
+    adName: string;
+    event: string;
+    amount: number;
+    fee: number;
+    status: "Success" | "Pending" | "Failed";
+}
+
+interface HistoryRow {
+    time: string;
+    adNameOrMethod: string;
+    amount: number;
+    status: string;
+}
+
+// ========= 假数据 =========
+
+let fakeAdAccountBalanceUSDC = 80.0;
+
+let myAds: MyAdRow[] = [
+    {
+        id: "my_ad_1",
+        name: "Twitter Followers Campaign",
+        status: "Active",
+        rewardPerTask: 0.5,
+        completed: 150,
+        spent: 75,
+        remainingBudget: 25
+    },
+    {
+        id: "my_ad_2",
+        name: "Landing Page Visit",
+        status: "Paused",
+        rewardPerTask: 0.2,
+        completed: 300,
+        spent: 60,
+        remainingBudget: 10
+    }
+];
+
+let spendRecords: SpendRecord[] = [
+    {
+        id: "sp_1",
+        time: "2026-01-14 10:12",
+        adName: "Twitter Followers Campaign",
+        event: "Task completed",
+        amount: 0.5,
+        fee: 0.025,
+        status: "Success"
+    },
+    {
+        id: "sp_2",
+        time: "2026-01-14 09:30",
+        adName: "Landing Page Visit",
+        event: "Task completed",
+        amount: 0.2,
+        fee: 0.01,
+        status: "Success"
+    }
+];
+
+const historyEarnings: HistoryRow[] = [
+    { time: "2026-01-14 10:12", adNameOrMethod: "Twitter Followers Campaign", amount: 0.5, status: "Completed" },
+    { time: "2026-01-14 09:30", adNameOrMethod: "Landing Page Visit", amount: 0.2, status: "Completed" }
+];
+
+const historySpending: HistoryRow[] = [
+    { time: "2026-01-14 10:12", adNameOrMethod: "Twitter Followers Campaign", amount: -0.525, status: "Success" },
+    { time: "2026-01-14 09:30", adNameOrMethod: "Landing Page Visit", amount: -0.21, status: "Success" }
+];
+
+const historyRecharge: HistoryRow[] = [
+    { time: "2026-01-13 18:20", adNameOrMethod: "Onramp (Card)", amount: 100, status: "Success" }
+];
+
+const fakeWalletAddress = "0xDEMO1234567890abcdef1234567890ABCDEF0000";
+
+// ========= 工具函数 =========
+
+function $(selector: string): HTMLElement {
+    const el = document.querySelector<HTMLElement>(selector);
+    if (!el) throw new Error(`Element not found: ${selector}`);
+    return el;
+}
+
+function q<T extends Element>(root: ParentNode, selector: string): T {
+    const el = root.querySelector<T>(selector);
+    if (!el) throw new Error(`Element not found: ${selector}`);
+    return el;
+}
+
+function cloneTemplate(id: string): HTMLElement {
+    const tpl = document.querySelector<HTMLTemplateElement>(`#${id}`);
+    if (!tpl) throw new Error(`Template not found: #${id}`);
+    const first = tpl.content.firstElementChild as HTMLElement | null;
+    if (!first) throw new Error(`Template #${id} has no root element`);
+    return first.cloneNode(true) as HTMLElement;
+}
+
+function formatUSDC(amount: number): string {
+    const n = Number(amount);
+    if (!Number.isFinite(n)) return "0.00 USDC";
+    return n.toFixed(2) + " USDC";
+}
+
+function showToast(message: string) {
+    const notification = document.querySelector<HTMLElement>("#notification");
+    if (!notification) {
+        alert(message);
+        return;
+    }
+    notification.textContent = message;
+    notification.classList.remove("error", "success");
+    notification.classList.add("info");
+    notification.style.opacity = "1";
+    setTimeout(() => {
+        if (notification) notification.style.opacity = "0";
+    }, 2000);
+}
+
+// ========= 顶部余额 & Advertise 仪表盘 =========
+
+function renderHeaderBalance() {
+    const balanceSpan = document.querySelector<HTMLElement>(".balance-value");
+    if (balanceSpan) balanceSpan.textContent = formatUSDC(fakeAdAccountBalanceUSDC);
+}
+
+function renderAdvertiseDashboard() {
+    const cards = document.querySelectorAll<HTMLElement>("#view-advertise .dashboard-card");
+
+    const card1Value = cards[0]?.querySelector<HTMLElement>(".card-value");
+    if (card1Value) card1Value.textContent = formatUSDC(fakeAdAccountBalanceUSDC);
+
+    const activeCount = myAds.filter((ad) => ad.status === "Active").length;
+    const card2Value = cards[1]?.querySelector<HTMLElement>(".card-value");
+    if (card2Value) card2Value.textContent = activeCount.toString();
+
+    const todaySpend = spendRecords.reduce((sum, r) => sum + (r.amount + r.fee), 0);
+    const card3Value = cards[2]?.querySelector<HTMLElement>(".card-value");
+    if (card3Value) card3Value.textContent = formatUSDC(todaySpend);
+
+    const weekSpend = todaySpend * 3;
+    const card4Value = cards[3]?.querySelector<HTMLElement>(".card-value");
+    if (card4Value) card4Value.textContent = formatUSDC(weekSpend);
+}
+
+// ========= My Ads 表格（模板 clone） =========
+
+function renderMyAdsTable() {
+    const tbody = document.querySelector<HTMLTableSectionElement>("#my-ads-tbody");
+    if (!tbody) return;
+
+    tbody.replaceChildren();
+
+    if (myAds.length === 0) {
+        tbody.appendChild(cloneTemplate("tpl-empty-my-ads-row") as any);
+        return;
+    }
+
+    myAds.forEach((ad) => {
+        const tr = cloneTemplate("tpl-my-ad-row") as HTMLTableRowElement;
+        tr.dataset.adId = ad.id;
+
+        q<HTMLElement>(tr, ".td-name").textContent = ad.name;
+        q<HTMLElement>(tr, ".td-status").textContent = ad.status;
+        q<HTMLElement>(tr, ".td-reward").textContent = formatUSDC(ad.rewardPerTask);
+        q<HTMLElement>(tr, ".td-completed").textContent = ad.completed.toString();
+        q<HTMLElement>(tr, ".td-spent").textContent = formatUSDC(ad.spent);
+        q<HTMLElement>(tr, ".td-remaining").textContent = formatUSDC(ad.remainingBudget);
+
+        const btnView = q<HTMLButtonElement>(tr, ".btn-view");
+        const btnToggle = q<HTMLButtonElement>(tr, ".btn-toggle");
+
+        btnView.addEventListener("click", () => showToast(`View ad: ${ad.name}`));
+
+        btnToggle.textContent = ad.status === "Active" ? "Pause" : "Resume";
+        btnToggle.addEventListener("click", () => {
+            ad.status = ad.status === "Active" ? "Paused" : "Active";
+            renderMyAdsTable();
+            renderAdvertiseDashboard();
+        });
+
+        tbody.appendChild(tr);
+    });
+}
+
+// ========= Recent Spending 表格（模板 clone） =========
+
+function renderSpendTable() {
+    const tbody = document.querySelector<HTMLTableSectionElement>("#spending-tbody");
+    if (!tbody) return;
+
+    tbody.replaceChildren();
+
+    if (spendRecords.length === 0) {
+        tbody.appendChild(cloneTemplate("tpl-empty-spend-row") as any);
+        return;
+    }
+
+    spendRecords.forEach((r) => {
+        const tr = cloneTemplate("tpl-spend-row") as HTMLTableRowElement;
+        tr.dataset.id = r.id;
+
+        q<HTMLElement>(tr, ".td-time").textContent = r.time;
+        q<HTMLElement>(tr, ".td-ad").textContent = r.adName;
+        q<HTMLElement>(tr, ".td-event").textContent = r.event;
+        q<HTMLElement>(tr, ".td-amount").textContent = formatUSDC(r.amount);
+        q<HTMLElement>(tr, ".td-fee").textContent = formatUSDC(r.fee);
+        q<HTMLElement>(tr, ".td-status").textContent = r.status;
+
+        tbody.appendChild(tr);
+    });
+}
+
+// ========= 发布广告向导（Wizard） =========
+
+let wizardCurrentStep = 1;
+const wizardMaxStep = 4;
+
+function openWizard() {
+    wizardCurrentStep = 1;
+    updateWizardUI();
+    document.querySelector<HTMLElement>("#publish-wizard-modal")?.classList.add("active");
+}
+
+function closeWizard() {
+    document.querySelector<HTMLElement>("#publish-wizard-modal")?.classList.remove("active");
+}
+
+function updateWizardUI() {
+    const steps = document.querySelectorAll<HTMLElement>(".wizard-step");
+    steps.forEach((stepEl) => {
+        const step = Number(stepEl.dataset.step);
+        stepEl.classList.toggle("active", step === wizardCurrentStep);
+        stepEl.classList.toggle("completed", step < wizardCurrentStep);
+    });
+
+    const contents = document.querySelectorAll<HTMLElement>(".wizard-content");
+    contents.forEach((c) => {
+        const step = Number(c.dataset.step);
+        c.classList.toggle("active", step === wizardCurrentStep);
+    });
+
+    const prevBtn = $("#btn-wizard-prev") as HTMLButtonElement;
+    const nextBtn = $("#btn-wizard-next") as HTMLButtonElement;
+    const submitBtn = $("#btn-wizard-submit") as HTMLButtonElement;
+
+    prevBtn.style.display = wizardCurrentStep > 1 ? "inline-flex" : "none";
+    if (wizardCurrentStep < wizardMaxStep) {
+        nextBtn.style.display = "inline-flex";
+        submitBtn.style.display = "none";
+    } else {
+        nextBtn.style.display = "none";
+        submitBtn.style.display = "inline-flex";
+        updateBudgetSummaryAndBalance();
+    }
+}
+
+function goWizardNext() {
+    if (wizardCurrentStep < wizardMaxStep) {
+        wizardCurrentStep++;
+        updateWizardUI();
+    }
+}
+
+function goWizardPrev() {
+    if (wizardCurrentStep > 1) {
+        wizardCurrentStep--;
+        updateWizardUI();
+    }
+}
+
+function updateBudgetSummaryAndBalance() {
+    const rewardInput = document.querySelector<HTMLInputElement>("#reward-amount");
+    const taskLimitInput = document.querySelector<HTMLInputElement>("#task-limit");
+
+    const reward = Number(rewardInput?.value || "0");
+    const tasks = Number(taskLimitInput?.value || "0");
+
+    const base = (Number.isFinite(reward) ? reward : 0) * (Number.isFinite(tasks) ? tasks : 0);
+    const fee = base * 0.05;
+    const total = base + fee;
+
+    $("#summary-reward").textContent = formatUSDC(reward);
+    $("#summary-tasks").textContent = Number.isFinite(tasks) ? tasks.toString() : "0";
+    $("#summary-fee").textContent = formatUSDC(fee);
+    $("#summary-total").textContent = formatUSDC(total);
+
+    $("#current-balance").textContent = formatUSDC(fakeAdAccountBalanceUSDC);
+
+    const balanceStatus = $("#balance-status");
+    balanceStatus.className = "balance-status";
+
+    if (total > 0 && total <= fakeAdAccountBalanceUSDC) {
+        balanceStatus.classList.add("sufficient");
+        balanceStatus.textContent = "Your balance is sufficient to publish this ad.";
+    } else if (total > fakeAdAccountBalanceUSDC) {
+        balanceStatus.classList.add("insufficient");
+        balanceStatus.textContent = "Insufficient balance. Please recharge before publishing.";
+    } else {
+        balanceStatus.textContent = "";
+    }
+}
+
+function submitWizard() {
+    const nameInput = document.querySelector<HTMLInputElement>("#ad-name");
+    const rewardInput = document.querySelector<HTMLInputElement>("#reward-amount");
+    const taskLimitInput = document.querySelector<HTMLInputElement>("#task-limit");
+
+    const name = nameInput?.value?.trim() || "Untitled Ad";
+    const reward = Number(rewardInput?.value || "0");
+    const tasks = Number(taskLimitInput?.value || "0");
+
+    const base = reward * tasks;
+    const fee = base * 0.05;
+    const total = base + fee;
+
+    if (total > fakeAdAccountBalanceUSDC) {
+        showToast("Insufficient ad account balance (fake check).");
+        return;
+    }
+
+    const newAd: MyAdRow = {
+        id: "my_ad_" + (myAds.length + 1),
+        name,
+        status: "Active",
+        rewardPerTask: reward || 0,
+        completed: 0,
+        spent: 0,
+        remainingBudget: total
+    };
+
+    myAds.unshift(newAd);
+    fakeAdAccountBalanceUSDC -= total * 0.1; // 演示：随便扣一点
+
+    renderMyAdsTable();
+    renderAdvertiseDashboard();
+    renderHeaderBalance();
+
+    closeWizard();
+    showToast("Ad published (fake).");
+}
+
+// ========= 充值弹窗 =========
+
+function openRechargeModal() {
+    const modal = document.querySelector<HTMLElement>("#recharge-modal");
+    const addrEl = document.querySelector<HTMLElement>("#wallet-address-display");
+    if (addrEl) addrEl.textContent = fakeWalletAddress;
+    modal?.classList.add("active");
+}
+
+function closeRechargeModal() {
+    document.querySelector<HTMLElement>("#recharge-modal")?.classList.remove("active");
+}
+
+function initRechargeModalEvents() {
+    document.querySelector<HTMLButtonElement>("#btn-recharge")?.addEventListener("click", openRechargeModal);
+    document.querySelector<HTMLButtonElement>("#btn-recharge-dashboard")?.addEventListener("click", openRechargeModal);
+    document.querySelector<HTMLButtonElement>("#close-recharge")?.addEventListener("click", closeRechargeModal);
+
+    document.querySelector<HTMLButtonElement>("#copy-address")?.addEventListener("click", async () => {
+        try {
+            if (navigator.clipboard) {
+                await navigator.clipboard.writeText(fakeWalletAddress);
+                showToast("Address copied (fake).");
+            } else {
+                showToast(fakeWalletAddress);
+            }
+        } catch {
+            showToast(fakeWalletAddress);
+        }
+    });
+
+    document.querySelector<HTMLButtonElement>("#btn-buy-card")?.addEventListener("click", () => {
+        showToast("Open onramp (fake).");
+    });
+}
+
+// ========= 历史记录弹窗（模板 clone） =========
+
+function openHistoryModal(defaultTab: "earnings" | "spending" | "recharge" = "spending") {
+    document.querySelector<HTMLElement>("#history-modal")?.classList.add("active");
+    switchHistoryTab(defaultTab);
+}
+
+function closeHistoryModal() {
+    document.querySelector<HTMLElement>("#history-modal")?.classList.remove("active");
+}
+
+function renderHistoryTable(tab: "earnings" | "spending" | "recharge", rows: HistoryRow[]) {
+    const tbody = document.querySelector<HTMLTableSectionElement>(
+        `.history-tab-content[data-tab="${tab}"] tbody`
+    );
+    if (!tbody) return;
+
+    tbody.replaceChildren();
+
+    if (rows.length === 0) {
+        const tr = cloneTemplate("tpl-empty-history-row") as HTMLTableRowElement;
+        const msg =
+            tab === "earnings" ? "No earnings yet" :
+                tab === "spending" ? "No spending yet" :
+                    "No recharge records";
+        q<HTMLElement>(tr, ".td-empty").textContent = msg;
+        tbody.appendChild(tr);
+        return;
+    }
+
+    rows.forEach((row) => {
+        const tr = cloneTemplate("tpl-history-row") as HTMLTableRowElement;
+        q<HTMLElement>(tr, ".td-time").textContent = row.time;
+        q<HTMLElement>(tr, ".td-name").textContent = row.adNameOrMethod;
+        q<HTMLElement>(tr, ".td-amount").textContent = formatUSDC(row.amount);
+        q<HTMLElement>(tr, ".td-status").textContent = row.status;
+        tbody.appendChild(tr);
+    });
+}
+
+function switchHistoryTab(tab: "earnings" | "spending" | "recharge") {
+    document.querySelectorAll<HTMLButtonElement>(".history-tab").forEach((btn) => {
+        btn.classList.toggle("active", btn.dataset.tab === tab);
+    });
+
+    document.querySelectorAll<HTMLElement>(".history-tab-content").forEach((c) => {
+        c.classList.toggle("active", c.dataset.tab === tab);
+    });
+
+    if (tab === "earnings") renderHistoryTable("earnings", historyEarnings);
+    if (tab === "spending") renderHistoryTable("spending", historySpending);
+    if (tab === "recharge") renderHistoryTable("recharge", historyRecharge);
+}
+
+function initHistoryModalEvents() {
+    document.querySelector<HTMLButtonElement>("#btn-history")?.addEventListener("click", () => openHistoryModal("spending"));
+    document.querySelector<HTMLButtonElement>("#close-history")?.addEventListener("click", closeHistoryModal);
+
+    document.querySelectorAll<HTMLButtonElement>(".history-tab").forEach((btn) => {
+        btn.addEventListener("click", () => {
+            const tab = (btn.dataset.tab || "spending") as any;
+            switchHistoryTab(tab);
+        });
+    });
+}
+
+// ========= 事件绑定：Wizard =========
+
+function initWizardEvents() {
+    document.querySelector<HTMLButtonElement>("#btn-publish-ad")?.addEventListener("click", openWizard);
+    document.querySelector<HTMLButtonElement>("#close-wizard")?.addEventListener("click", closeWizard);
+    document.querySelector<HTMLButtonElement>("#btn-wizard-prev")?.addEventListener("click", goWizardPrev);
+    document.querySelector<HTMLButtonElement>("#btn-wizard-next")?.addEventListener("click", goWizardNext);
+    document.querySelector<HTMLButtonElement>("#btn-wizard-submit")?.addEventListener("click", submitWizard);
+
+    document.querySelector<HTMLInputElement>("#reward-amount")?.addEventListener("input", updateBudgetSummaryAndBalance);
+    document.querySelector<HTMLInputElement>("#task-limit")?.addEventListener("input", updateBudgetSummaryAndBalance);
+}
+
+// ========= 初始化入口 =========
+
+function initAdvertise() {
+    renderHeaderBalance();
+    renderAdvertiseDashboard();
+    renderMyAdsTable();
+    renderSpendTable();
+
+    initWizardEvents();
+    initRechargeModalEvents();
+    initHistoryModalEvents();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    try {
+        initAdvertise();
+    } catch (err) {
+        console.error("Advertise init error:", err);
+    }
+});

--- a/src/popup/ad_plaza.ts
+++ b/src/popup/ad_plaza.ts
@@ -1,5 +1,5 @@
 // ad_plaza.ts
-// 用假数据驱动 Ad Plaza 的所有界面和按钮交互
+// 用假数据驱动 Earn 页面的界面和按钮交互
 // ✅ 已移除所有 document.createElement：全部改为 HTML <template> + cloneNode
 
 // ========= 类型定义 =========
@@ -22,35 +22,6 @@ interface EarnAd {
     popularityScore: number;
     createdAt: number; // 时间戳，方便排序
     detailUrl: string;
-}
-
-type AdStatus = "Active" | "Paused" | "Ended" | "Balance Low";
-
-interface MyAdRow {
-    id: string;
-    name: string;
-    status: AdStatus;
-    rewardPerTask: number;
-    completed: number;
-    spent: number;
-    remainingBudget: number;
-}
-
-interface SpendRecord {
-    id: string;
-    time: string;
-    adName: string;
-    event: string;
-    amount: number;
-    fee: number;
-    status: "Success" | "Pending" | "Failed";
-}
-
-interface HistoryRow {
-    time: string;
-    adNameOrMethod: string;
-    amount: number;
-    status: string;
 }
 
 // ========= 假数据 =========
@@ -126,74 +97,12 @@ const fakeEarnAds: EarnAd[] = [
     }
 ];
 
-let fakeUserBalanceUSDC = 123.45;     // 顶部 Balance
-let fakeAdAccountBalanceUSDC = 80.0;  // Advertise 仪表盘里的 Ad Account Balance
-
-let myAds: MyAdRow[] = [
-    {
-        id: "my_ad_1",
-        name: "Twitter Followers Campaign",
-        status: "Active",
-        rewardPerTask: 0.5,
-        completed: 150,
-        spent: 75,
-        remainingBudget: 25
-    },
-    {
-        id: "my_ad_2",
-        name: "Landing Page Visit",
-        status: "Paused",
-        rewardPerTask: 0.2,
-        completed: 300,
-        spent: 60,
-        remainingBudget: 10
-    }
-];
-
-let spendRecords: SpendRecord[] = [
-    {
-        id: "sp_1",
-        time: "2026-01-14 10:12",
-        adName: "Twitter Followers Campaign",
-        event: "Task completed",
-        amount: 0.5,
-        fee: 0.025,
-        status: "Success"
-    },
-    {
-        id: "sp_2",
-        time: "2026-01-14 09:30",
-        adName: "Landing Page Visit",
-        event: "Task completed",
-        amount: 0.2,
-        fee: 0.01,
-        status: "Success"
-    }
-];
-
-const historyEarnings: HistoryRow[] = [
-    { time: "2026-01-14 10:12", adNameOrMethod: "Twitter Followers Campaign", amount: 0.5, status: "Completed" },
-    { time: "2026-01-14 09:30", adNameOrMethod: "Landing Page Visit", amount: 0.2, status: "Completed" }
-];
-
-const historySpending: HistoryRow[] = [
-    { time: "2026-01-14 10:12", adNameOrMethod: "Twitter Followers Campaign", amount: -0.525, status: "Success" },
-    { time: "2026-01-14 09:30", adNameOrMethod: "Landing Page Visit", amount: -0.21, status: "Success" }
-];
-
-const historyRecharge: HistoryRow[] = [
-    { time: "2026-01-13 18:20", adNameOrMethod: "Onramp (Card)", amount: 100, status: "Success" }
-];
-
-const fakeWalletAddress = "0xDEMO1234567890abcdef1234567890ABCDEF0000";
+const fakeWithdrawableUSDC = 12.34;
+const fakeTotalEarnedUSDC = 23.45;
+const fakeTodayEarnedUSDC = 1.25;
+const fakePendingUSDC = 0.75;
 
 // ========= 工具函数 =========
-
-function $(selector: string): HTMLElement {
-    const el = document.querySelector<HTMLElement>(selector);
-    if (!el) throw new Error(`Element not found: ${selector}`);
-    return el;
-}
 
 function q<T extends Element>(root: ParentNode, selector: string): T {
     const el = root.querySelector<T>(selector);
@@ -427,375 +336,21 @@ function renderEarnAds() {
     });
 }
 
-// ========= 顶部余额 & Earn 概览卡 =========
+// ========= Earn 主卡信息 =========
 
-function renderHeaderBalance() {
-    const balanceSpan = document.querySelector<HTMLElement>(".balance-value");
-    if (balanceSpan) balanceSpan.textContent = formatUSDC(fakeUserBalanceUSDC);
+function renderEarnSummary() {
+    const withdrawable = document.querySelector<HTMLElement>("#withdrawable-amount");
+    const total = document.querySelector<HTMLElement>("#total-earned");
+    const today = document.querySelector<HTMLElement>("#today-earned");
+    const pending = document.querySelector<HTMLElement>("#pending-earned");
+
+    if (withdrawable) withdrawable.textContent = formatUSDC(fakeWithdrawableUSDC);
+    if (total) total.textContent = formatUSDC(fakeTotalEarnedUSDC);
+    if (today) today.textContent = formatUSDC(fakeTodayEarnedUSDC);
+    if (pending) pending.textContent = formatUSDC(fakePendingUSDC);
 }
 
-function renderEarnOverview() {
-    const totalCard = document.querySelector<HTMLElement>(
-        "#view-earn .earnings-overview .overview-card:nth-child(1) .card-value"
-    );
-    const todayCard = document.querySelector<HTMLElement>(
-        "#view-earn .earnings-overview .overview-card:nth-child(2) .card-value"
-    );
-    const pendingCard = document.querySelector<HTMLElement>(
-        "#view-earn .earnings-overview .overview-card:nth-child(3) .card-value"
-    );
-
-    if (totalCard) totalCard.textContent = formatUSDC(23.45);
-    if (todayCard) todayCard.textContent = formatUSDC(1.25);
-    if (pendingCard) pendingCard.textContent = formatUSDC(0.75);
-}
-
-// ========= Advertise 仪表盘 =========
-
-function renderAdvertiseDashboard() {
-    const cards = document.querySelectorAll<HTMLElement>("#view-advertise .dashboard-card");
-
-    const card1Value = cards[0]?.querySelector<HTMLElement>(".card-value");
-    if (card1Value) card1Value.textContent = formatUSDC(fakeAdAccountBalanceUSDC);
-
-    const activeCount = myAds.filter((ad) => ad.status === "Active").length;
-    const card2Value = cards[1]?.querySelector<HTMLElement>(".card-value");
-    if (card2Value) card2Value.textContent = activeCount.toString();
-
-    const todaySpend = spendRecords.reduce((sum, r) => sum + (r.amount + r.fee), 0);
-    const card3Value = cards[2]?.querySelector<HTMLElement>(".card-value");
-    if (card3Value) card3Value.textContent = formatUSDC(todaySpend);
-
-    const weekSpend = todaySpend * 3;
-    const card4Value = cards[3]?.querySelector<HTMLElement>(".card-value");
-    if (card4Value) card4Value.textContent = formatUSDC(weekSpend);
-}
-
-// ========= My Ads 表格（模板 clone） =========
-
-function renderMyAdsTable() {
-    const tbody = document.querySelector<HTMLTableSectionElement>("#my-ads-tbody");
-    if (!tbody) return;
-
-    tbody.replaceChildren();
-
-    if (myAds.length === 0) {
-        tbody.appendChild(cloneTemplate("tpl-empty-my-ads-row") as any);
-        return;
-    }
-
-    myAds.forEach((ad) => {
-        const tr = cloneTemplate("tpl-my-ad-row") as HTMLTableRowElement;
-        tr.dataset.adId = ad.id;
-
-        q<HTMLElement>(tr, ".td-name").textContent = ad.name;
-        q<HTMLElement>(tr, ".td-status").textContent = ad.status;
-        q<HTMLElement>(tr, ".td-reward").textContent = formatUSDC(ad.rewardPerTask);
-        q<HTMLElement>(tr, ".td-completed").textContent = ad.completed.toString();
-        q<HTMLElement>(tr, ".td-spent").textContent = formatUSDC(ad.spent);
-        q<HTMLElement>(tr, ".td-remaining").textContent = formatUSDC(ad.remainingBudget);
-
-        const btnView = q<HTMLButtonElement>(tr, ".btn-view");
-        const btnToggle = q<HTMLButtonElement>(tr, ".btn-toggle");
-
-        btnView.addEventListener("click", () => showToast(`View ad: ${ad.name}`));
-
-        btnToggle.textContent = ad.status === "Active" ? "Pause" : "Resume";
-        btnToggle.addEventListener("click", () => {
-            ad.status = ad.status === "Active" ? "Paused" : "Active";
-            renderMyAdsTable();
-            renderAdvertiseDashboard();
-        });
-
-        tbody.appendChild(tr);
-    });
-}
-
-// ========= Recent Spending 表格（模板 clone） =========
-
-function renderSpendTable() {
-    const tbody = document.querySelector<HTMLTableSectionElement>("#spending-tbody");
-    if (!tbody) return;
-
-    tbody.replaceChildren();
-
-    if (spendRecords.length === 0) {
-        tbody.appendChild(cloneTemplate("tpl-empty-spend-row") as any);
-        return;
-    }
-
-    spendRecords.forEach((r) => {
-        const tr = cloneTemplate("tpl-spend-row") as HTMLTableRowElement;
-        tr.dataset.id = r.id;
-
-        q<HTMLElement>(tr, ".td-time").textContent = r.time;
-        q<HTMLElement>(tr, ".td-ad").textContent = r.adName;
-        q<HTMLElement>(tr, ".td-event").textContent = r.event;
-        q<HTMLElement>(tr, ".td-amount").textContent = formatUSDC(r.amount);
-        q<HTMLElement>(tr, ".td-fee").textContent = formatUSDC(r.fee);
-        q<HTMLElement>(tr, ".td-status").textContent = r.status;
-
-        tbody.appendChild(tr);
-    });
-}
-
-// ========= 发布广告向导（Wizard） =========
-
-let wizardCurrentStep = 1;
-const wizardMaxStep = 4;
-
-function openWizard() {
-    wizardCurrentStep = 1;
-    updateWizardUI();
-    document.querySelector<HTMLElement>("#publish-wizard-modal")?.classList.add("active");
-}
-
-function closeWizard() {
-    document.querySelector<HTMLElement>("#publish-wizard-modal")?.classList.remove("active");
-}
-
-function updateWizardUI() {
-    const steps = document.querySelectorAll<HTMLElement>(".wizard-step");
-    steps.forEach((stepEl) => {
-        const step = Number(stepEl.dataset.step);
-        stepEl.classList.toggle("active", step === wizardCurrentStep);
-        stepEl.classList.toggle("completed", step < wizardCurrentStep);
-    });
-
-    const contents = document.querySelectorAll<HTMLElement>(".wizard-content");
-    contents.forEach((c) => {
-        const step = Number(c.dataset.step);
-        c.classList.toggle("active", step === wizardCurrentStep);
-    });
-
-    const prevBtn = $("#btn-wizard-prev") as HTMLButtonElement;
-    const nextBtn = $("#btn-wizard-next") as HTMLButtonElement;
-    const submitBtn = $("#btn-wizard-submit") as HTMLButtonElement;
-
-    prevBtn.style.display = wizardCurrentStep > 1 ? "inline-flex" : "none";
-    if (wizardCurrentStep < wizardMaxStep) {
-        nextBtn.style.display = "inline-flex";
-        submitBtn.style.display = "none";
-    } else {
-        nextBtn.style.display = "none";
-        submitBtn.style.display = "inline-flex";
-        updateBudgetSummaryAndBalance();
-    }
-}
-
-function goWizardNext() {
-    if (wizardCurrentStep < wizardMaxStep) {
-        wizardCurrentStep++;
-        updateWizardUI();
-    }
-}
-
-function goWizardPrev() {
-    if (wizardCurrentStep > 1) {
-        wizardCurrentStep--;
-        updateWizardUI();
-    }
-}
-
-function updateBudgetSummaryAndBalance() {
-    const rewardInput = document.querySelector<HTMLInputElement>("#reward-amount");
-    const taskLimitInput = document.querySelector<HTMLInputElement>("#task-limit");
-
-    const reward = Number(rewardInput?.value || "0");
-    const tasks = Number(taskLimitInput?.value || "0");
-
-    const base = (Number.isFinite(reward) ? reward : 0) * (Number.isFinite(tasks) ? tasks : 0);
-    const fee = base * 0.05;
-    const total = base + fee;
-
-    $("#summary-reward").textContent = formatUSDC(reward);
-    $("#summary-tasks").textContent = Number.isFinite(tasks) ? tasks.toString() : "0";
-    $("#summary-fee").textContent = formatUSDC(fee);
-    $("#summary-total").textContent = formatUSDC(total);
-
-    $("#current-balance").textContent = formatUSDC(fakeAdAccountBalanceUSDC);
-
-    const balanceStatus = $("#balance-status");
-    balanceStatus.className = "balance-status";
-
-    if (total > 0 && total <= fakeAdAccountBalanceUSDC) {
-        balanceStatus.classList.add("sufficient");
-        balanceStatus.textContent = "Your balance is sufficient to publish this ad.";
-    } else if (total > fakeAdAccountBalanceUSDC) {
-        balanceStatus.classList.add("insufficient");
-        balanceStatus.textContent = "Insufficient balance. Please recharge before publishing.";
-    } else {
-        balanceStatus.textContent = "";
-    }
-}
-
-function submitWizard() {
-    const nameInput = document.querySelector<HTMLInputElement>("#ad-name");
-    const rewardInput = document.querySelector<HTMLInputElement>("#reward-amount");
-    const taskLimitInput = document.querySelector<HTMLInputElement>("#task-limit");
-
-    const name = nameInput?.value?.trim() || "Untitled Ad";
-    const reward = Number(rewardInput?.value || "0");
-    const tasks = Number(taskLimitInput?.value || "0");
-
-    const base = reward * tasks;
-    const fee = base * 0.05;
-    const total = base + fee;
-
-    if (total > fakeAdAccountBalanceUSDC) {
-        showToast("Insufficient ad account balance (fake check).");
-        return;
-    }
-
-    const newAd: MyAdRow = {
-        id: "my_ad_" + (myAds.length + 1),
-        name,
-        status: "Active",
-        rewardPerTask: reward || 0,
-        completed: 0,
-        spent: 0,
-        remainingBudget: total
-    };
-
-    myAds.unshift(newAd);
-    fakeAdAccountBalanceUSDC -= total * 0.1; // 演示：随便扣一点
-
-    renderMyAdsTable();
-    renderAdvertiseDashboard();
-    renderHeaderBalance();
-
-    closeWizard();
-    showToast("Ad published (fake).");
-}
-
-// ========= 充值弹窗 =========
-
-function openRechargeModal() {
-    const modal = document.querySelector<HTMLElement>("#recharge-modal");
-    const addrEl = document.querySelector<HTMLElement>("#wallet-address-display");
-    if (addrEl) addrEl.textContent = fakeWalletAddress;
-    modal?.classList.add("active");
-}
-
-function closeRechargeModal() {
-    document.querySelector<HTMLElement>("#recharge-modal")?.classList.remove("active");
-}
-
-function initRechargeModalEvents() {
-    document.querySelector<HTMLButtonElement>("#btn-recharge")?.addEventListener("click", openRechargeModal);
-    document.querySelector<HTMLButtonElement>("#btn-recharge-dashboard")?.addEventListener("click", openRechargeModal);
-    document.querySelector<HTMLButtonElement>("#close-recharge")?.addEventListener("click", closeRechargeModal);
-
-    document.querySelector<HTMLButtonElement>("#copy-address")?.addEventListener("click", async () => {
-        try {
-            if (navigator.clipboard) {
-                await navigator.clipboard.writeText(fakeWalletAddress);
-                showToast("Address copied (fake).");
-            } else {
-                showToast(fakeWalletAddress);
-            }
-        } catch {
-            showToast(fakeWalletAddress);
-        }
-    });
-
-    document.querySelector<HTMLButtonElement>("#btn-buy-card")?.addEventListener("click", () => {
-        showToast("Open onramp (fake).");
-    });
-}
-
-// ========= 历史记录弹窗（模板 clone） =========
-
-function openHistoryModal(defaultTab: "earnings" | "spending" | "recharge" = "earnings") {
-    document.querySelector<HTMLElement>("#history-modal")?.classList.add("active");
-    switchHistoryTab(defaultTab);
-}
-
-function closeHistoryModal() {
-    document.querySelector<HTMLElement>("#history-modal")?.classList.remove("active");
-}
-
-function renderHistoryTable(tab: "earnings" | "spending" | "recharge", rows: HistoryRow[]) {
-    const tbody = document.querySelector<HTMLTableSectionElement>(
-        `.history-tab-content[data-tab="${tab}"] tbody`
-    );
-    if (!tbody) return;
-
-    tbody.replaceChildren();
-
-    if (rows.length === 0) {
-        const tr = cloneTemplate("tpl-empty-history-row") as HTMLTableRowElement;
-        const msg =
-            tab === "earnings" ? "No earnings yet" :
-                tab === "spending" ? "No spending yet" :
-                    "No recharge records";
-        q<HTMLElement>(tr, ".td-empty").textContent = msg;
-        tbody.appendChild(tr);
-        return;
-    }
-
-    rows.forEach((row) => {
-        const tr = cloneTemplate("tpl-history-row") as HTMLTableRowElement;
-        q<HTMLElement>(tr, ".td-time").textContent = row.time;
-        q<HTMLElement>(tr, ".td-name").textContent = row.adNameOrMethod;
-        q<HTMLElement>(tr, ".td-amount").textContent = formatUSDC(row.amount);
-        q<HTMLElement>(tr, ".td-status").textContent = row.status;
-        tbody.appendChild(tr);
-    });
-}
-
-function switchHistoryTab(tab: "earnings" | "spending" | "recharge") {
-    document.querySelectorAll<HTMLButtonElement>(".history-tab").forEach((btn) => {
-        btn.classList.toggle("active", btn.dataset.tab === tab);
-    });
-
-    document.querySelectorAll<HTMLElement>(".history-tab-content").forEach((c) => {
-        c.classList.toggle("active", c.dataset.tab === tab);
-    });
-
-    if (tab === "earnings") renderHistoryTable("earnings", historyEarnings);
-    if (tab === "spending") renderHistoryTable("spending", historySpending);
-    if (tab === "recharge") renderHistoryTable("recharge", historyRecharge);
-}
-
-function initHistoryModalEvents() {
-    document.querySelector<HTMLButtonElement>("#btn-history")?.addEventListener("click", () => openHistoryModal("spending"));
-    document.querySelector<HTMLButtonElement>("#btn-my-earnings")?.addEventListener("click", () => openHistoryModal("earnings"));
-    document.querySelector<HTMLButtonElement>("#close-history")?.addEventListener("click", closeHistoryModal);
-
-    document.querySelectorAll<HTMLButtonElement>(".history-tab").forEach((btn) => {
-        btn.addEventListener("click", () => {
-            const tab = (btn.dataset.tab || "earnings") as any;
-            switchHistoryTab(tab);
-        });
-    });
-}
-
-// ========= 模式切换 (Earn / Advertise) =========
-
-function initModeSwitch() {
-    const btnEarn = document.querySelector<HTMLButtonElement>("#mode-earn");
-    const btnAdv = document.querySelector<HTMLButtonElement>("#mode-advertise");
-    const viewEarn = document.querySelector<HTMLElement>("#view-earn");
-    const viewAdv = document.querySelector<HTMLElement>("#view-advertise");
-    if (!btnEarn || !btnAdv || !viewEarn || !viewAdv) return;
-
-    btnEarn.addEventListener("click", () => {
-        btnEarn.classList.add("active");
-        btnAdv.classList.remove("active");
-        viewEarn.classList.add("active");
-        viewAdv.classList.remove("active");
-    });
-
-    btnAdv.addEventListener("click", () => {
-        btnAdv.classList.add("active");
-        btnEarn.classList.remove("active");
-        viewAdv.classList.add("active");
-        viewEarn.classList.remove("active");
-    });
-}
-
-// ========= 事件绑定：筛选 / Wizard =========
+// ========= 事件绑定：筛选 / 按钮 =========
 
 function initEarnFiltersEvents() {
     const onAnyFilterChanged = () => {
@@ -829,33 +384,28 @@ function initEarnFiltersEvents() {
     });
 }
 
-function initWizardEvents() {
-    document.querySelector<HTMLButtonElement>("#btn-publish-ad")?.addEventListener("click", openWizard);
-    document.querySelector<HTMLButtonElement>("#close-wizard")?.addEventListener("click", closeWizard);
-    document.querySelector<HTMLButtonElement>("#btn-wizard-prev")?.addEventListener("click", goWizardPrev);
-    document.querySelector<HTMLButtonElement>("#btn-wizard-next")?.addEventListener("click", goWizardNext);
-    document.querySelector<HTMLButtonElement>("#btn-wizard-submit")?.addEventListener("click", submitWizard);
+function initEarnActions() {
+    document.querySelector<HTMLButtonElement>("#btn-withdraw")?.addEventListener("click", () => {
+        showToast("Withdraw request submitted (fake).");
+    });
 
-    document.querySelector<HTMLInputElement>("#reward-amount")?.addEventListener("input", updateBudgetSummaryAndBalance);
-    document.querySelector<HTMLInputElement>("#task-limit")?.addEventListener("input", updateBudgetSummaryAndBalance);
+    document.querySelector<HTMLButtonElement>("#btn-earn-activity")?.addEventListener("click", () => {
+        showToast("Open earn activity (fake).");
+    });
+
+    document.querySelector<HTMLButtonElement>("#btn-open-advertise")?.addEventListener("click", () => {
+        window.location.href = "ad_advertise.html";
+    });
 }
 
 // ========= 初始化入口 =========
 
 function initAdPlaza() {
-    renderHeaderBalance();
-    renderEarnOverview();
+    renderEarnSummary();
     renderEarnAds();
 
-    renderAdvertiseDashboard();
-    renderMyAdsTable();
-    renderSpendTable();
-
-    initModeSwitch();
     initEarnFiltersEvents();
-    initWizardEvents();
-    initRechargeModalEvents();
-    initHistoryModalEvents();
+    initEarnActions();
     updateFilterToolsUI();
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,6 +123,7 @@ module.exports = (env, argv) => {
             fees: path.resolve(__dirname, './src/popup/fees.ts'),
             buy_usdc: path.resolve(__dirname, './src/popup/buy_usdc.ts'),
             ad_plaza: path.resolve(__dirname, './src/popup/ad_plaza.ts'),
+            ad_advertise: path.resolve(__dirname, './src/popup/ad_advertise.ts'),
         },
         target: 'web',
     };


### PR DESCRIPTION
### Motivation
- Separate the Earn (user-facing) and Advertise (advertiser-facing) surfaces so each page only contains its own DOM/logic/styles. 
- Simplify Earn UI to focus on withdraw/earnings and filters and avoid cross-page header controls and mode switching.
- Remove the Chrome native search cancel button collision (double X) by keeping the custom clear control and hiding the browser's built-in cancel control via CSS.

### Description
- Split Advertise into a new three-file bundle: `src/popup/ad_advertise.ts`, `dist/html/ad_advertise.html`, and `dist/css/ad_advertise.css` and moved the `#view-advertise` DOM, publish wizard, recharge/history modals, tables, and related templates/logic into that new page. 
- Reworked Earn into an Earn-only page by editing `dist/html/ad_plaza.html`, `dist/css/ad_plaza.css`, and `src/popup/ad_plaza.ts` to remove the `mode-switch` and header balance/recharge/history, add a right-hand main ad list and left-side Withdraw + Activity + Filters column, and replace the previous header controls with the `btn-open-advertise` button that opens `ad_advertise.html`. 
- Moved Advertise-specific styles out of `ad_plaza.css` into `ad_advertise.css` and added Earn-specific layout CSS (`.earn-layout`, `.earn-left`, `.earn-right`, withdraw card, etc.), while preserving the `input[type="search"]` WebKit rules to hide the native search cancel button. 
- Removed Advertise-related runtime wiring from `src/popup/ad_plaza.ts` and preserved Earn filter/render/withdraw flows; implemented Advertise runtime in `src/popup/ad_advertise.ts`. 
- Registered the new bundle entry in `webpack.config.js` as `ad_advertise` so it can be built alongside `ad_plaza` via the existing build pipeline.

### Testing
- Ran a local static server serving `dist` and used Playwright to open `dist/html/ad_plaza.html` and `dist/html/ad_advertise.html` and captured screenshots, confirming the new Earn left/right layout and that the Advertise page renders its dashboard and tables from the new HTML/CSS; screenshot artifacts were produced successfully. 
- Observed that runtime JS bundles were not present in `dist/js` during the validation run (`/js/ad_plaza.js` and `/js/ad_advertise.js` returned 404) because the project build (`npm run build`) was not executed in this session, so interactive behaviors (modals/wizard/button JS) could not be exercised end-to-end. 
- Note: `webpack.config.js` was updated to add the `ad_advertise` entry; please run `npm run build` / CI to produce the new JS bundles and verify interactive behavior and that console shows no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675434fb7c8325afc91d9713217260)